### PR TITLE
Pause live plot updating

### DIFF
--- a/gui/plotting.py
+++ b/gui/plotting.py
@@ -2,7 +2,8 @@ import time
 import numpy as np
 from datetime import timedelta
 import pyqtgraph as pg
-from pyqtgraph.Qt import QtGui
+from pyqtgraph.Qt import QtGui, QtWidgets
+from PyQt5.QtCore import Qt
 
 from config.gui_settings import event_history_len, state_history_len, analog_history_dur
 from gui.utility import detachableTabWidget
@@ -26,16 +27,20 @@ class Task_plot(QtGui.QWidget):
 
         # Setup plots
 
+        self.live_updating_checkbox = QtWidgets.QCheckBox('Live Updating')
+        self.live_updating_checkbox.setChecked(True)
+        self.live_updating_checkbox.setEnabled(False)
         self.events_plot.axis.setXLink(self.states_plot.axis)
         self.analog_plot.axis.setXLink(self.states_plot.axis)
         self.analog_plot.axis.setVisible(False)
 
         # create layout
 
-        self.vertical_layout = QtGui.QVBoxLayout()
-        self.vertical_layout.addWidget(self.states_plot.axis,1)
-        self.vertical_layout.addWidget(self.events_plot.axis,1)
-        self.vertical_layout.addWidget(self.analog_plot.axis,1)
+        self.vertical_layout = QtGui.QGridLayout()
+        self.vertical_layout.addWidget(self.states_plot.axis,0,0,1,3)
+        self.vertical_layout.addWidget(self.events_plot.axis,1,0,1,3)
+        self.vertical_layout.addWidget(self.analog_plot.axis,2,0,1,3)
+        self.vertical_layout.addWidget(self.live_updating_checkbox,3,0,1,3,Qt.AlignCenter)
         self.setLayout(self.vertical_layout)
 
     def set_state_machine(self, sm_info):
@@ -52,6 +57,8 @@ class Task_plot(QtGui.QWidget):
             self.events_plot.axis.getAxis('bottom').setLabel('Time (seconds)')
 
     def run_start(self, recording):
+        self.live_updating_checkbox.setChecked(True)
+        self.live_updating_checkbox.setEnabled(True)
         self.start_time = time.time()
         self.states_plot.run_start()
         self.events_plot.run_start()
@@ -60,6 +67,7 @@ class Task_plot(QtGui.QWidget):
             self.run_clock.recording()
 
     def run_stop(self):
+        self.live_updating_checkbox.setEnabled(False)
         self.run_clock.run_stop()
 
     def process_data(self, new_data):
@@ -70,11 +78,13 @@ class Task_plot(QtGui.QWidget):
 
     def update(self):
         '''Update plots.'''
-        run_time = time.time() - self.start_time
-        self.states_plot.update(run_time)
-        self.events_plot.update(run_time)
-        self.analog_plot.update(run_time)
-        self.run_clock.update(run_time)
+        if self.live_updating_checkbox.isChecked():
+            run_time = time.time() - self.start_time
+            self.states_plot.update(run_time)
+            self.events_plot.update(run_time)
+            self.analog_plot.update(run_time)
+            self.run_clock.update(run_time)
+
 
 # States_plot --------------------------------------------------------
 

--- a/gui/plotting.py
+++ b/gui/plotting.py
@@ -26,10 +26,9 @@ class Task_plot(QtGui.QWidget):
         self.run_clock   = Run_clock(self.states_plot.axis)
 
         # Setup plots
-
-        self.live_updating_checkbox = QtWidgets.QCheckBox('Live Updating')
-        self.live_updating_checkbox.setChecked(True)
-        self.live_updating_checkbox.setEnabled(False)
+        self.pause_button = QtGui.QPushButton('Pause plots')
+        self.pause_button.setEnabled(False)
+        self.pause_button.setCheckable(True)
         self.events_plot.axis.setXLink(self.states_plot.axis)
         self.analog_plot.axis.setXLink(self.states_plot.axis)
         self.analog_plot.axis.setVisible(False)
@@ -40,7 +39,7 @@ class Task_plot(QtGui.QWidget):
         self.vertical_layout.addWidget(self.states_plot.axis,0,0,1,3)
         self.vertical_layout.addWidget(self.events_plot.axis,1,0,1,3)
         self.vertical_layout.addWidget(self.analog_plot.axis,2,0,1,3)
-        self.vertical_layout.addWidget(self.live_updating_checkbox,3,0,1,3,Qt.AlignCenter)
+        self.vertical_layout.addWidget(self.pause_button,3,0,1,3,Qt.AlignCenter)
         self.setLayout(self.vertical_layout)
 
     def set_state_machine(self, sm_info):
@@ -57,8 +56,8 @@ class Task_plot(QtGui.QWidget):
             self.events_plot.axis.getAxis('bottom').setLabel('Time (seconds)')
 
     def run_start(self, recording):
-        self.live_updating_checkbox.setChecked(True)
-        self.live_updating_checkbox.setEnabled(True)
+        self.pause_button.setChecked(False)
+        self.pause_button.setEnabled(True)
         self.start_time = time.time()
         self.states_plot.run_start()
         self.events_plot.run_start()
@@ -67,7 +66,7 @@ class Task_plot(QtGui.QWidget):
             self.run_clock.recording()
 
     def run_stop(self):
-        self.live_updating_checkbox.setEnabled(False)
+        self.pause_button.setEnabled(False)
         self.run_clock.run_stop()
 
     def process_data(self, new_data):
@@ -78,7 +77,7 @@ class Task_plot(QtGui.QWidget):
 
     def update(self):
         '''Update plots.'''
-        if self.live_updating_checkbox.isChecked():
+        if not self.pause_button.isChecked():
             run_time = time.time() - self.start_time
             self.states_plot.update(run_time)
             self.events_plot.update(run_time)


### PR DESCRIPTION
If you want to scroll through the recent history of a plot, or zoom in on a particular sequence of events, it is nice to be able to pause the live updating. With the plot updating paused, the events that you are interested in viewing are no longer moving targets.

This pull request adds a "live updating" checkbox below the plots. It is on by default when you start a session.