### PR TITLE
use recording attr to define Analog IO

### DIFF
--- a/pyControl/hardware.py
+++ b/pyControl/hardware.py
@@ -93,7 +93,7 @@ def off():
 def get_analog_inputs():
     # Print dict of analog inputs {name: {'ID': ID, 'Fs':sampling rate}}
     print({io.name:{'ID': io.ID, 'Fs': io.sampling_rate}
-          for io in IO_dict.values() if isinstance(io, Analog_input)})
+          for io in IO_dict.values() if hasattr(io,'recording')})
 
 # IO_object -------------------------------------------------------------------
 


### PR DESCRIPTION
To allow other classes similar to `Analog_input` work (ie send interrupts and data to the GUI etc).