### PR TITLE
Custom variable dialogs

### DIFF
--- a/config/gui_settings.py
+++ b/config/gui_settings.py
@@ -7,3 +7,7 @@ update_interval = 20 # Interval between calls to the GUIs update function (ms).
 event_history_len  = 200  # Length of event history to plot (# events).
 state_history_len  = 100  # Length of state history to plot (# states). 
 analog_history_dur = 12   # Duration of analog signal history to plot (seconds).
+
+# uncomment either or both of the following variables to customize pyControl's font size
+#ui_font_size = 12 	# the font size of UI elements (button text, label text, line edit text, etc.)
+#log_font_size =  12	# the font size of the pyControl data logger 

--- a/gui/GUI_main.py
+++ b/gui/GUI_main.py
@@ -188,6 +188,28 @@ class GUI_main(QtGui.QMainWindow):
 def launch_GUI():
     '''Launch the pyControl GUI.'''
     app = QtGui.QApplication(sys.argv)
+    app.setStyle('Fusion')
+    style = """
+        QPushButton:hover{
+            background-color:CornflowerBlue;
+        }
+        QComboBox:hover{
+            background-color:CornflowerBlue;
+        }
+        QLineEdit[readOnly=\"false\"]:hover{
+            border: 1px solid CornflowerBlue;
+        }
+        QTabBar:tab:hover{
+            color:  #4881ea;
+        }
+        QCheckBox:hover{
+            color:  #4881ea ;
+        }
+        QTableView:item:hover{
+            border: 1px solid CornflowerBlue;
+        }
+    """
+    app.setStyleSheet(style)
     gui_main = GUI_main()
     gui_main.app = app # To allow app functions to be called from GUI.
     sys.excepthook = gui_main.excepthook

--- a/gui/GUI_main.py
+++ b/gui/GUI_main.py
@@ -13,6 +13,11 @@ from gui.configure_experiment_tab import Configure_experiment_tab
 from gui.run_experiment_tab import Run_experiment_tab
 from gui.setups_tab import Setups_tab
 
+try:
+    from config.gui_settings import ui_font_size
+except:
+    ui_font_size = None
+
 # --------------------------------------------------------------------------------
 # GUI_main
 # --------------------------------------------------------------------------------
@@ -210,6 +215,10 @@ def launch_GUI():
         }
     """
     app.setStyleSheet(style)
+    font = QtGui.QFont()
+    if ui_font_size:
+        font.setPixelSize(ui_font_size)
+    app.setFont(font)
     gui_main = GUI_main()
     gui_main.app = app # To allow app functions to be called from GUI.
     sys.excepthook = gui_main.excepthook

--- a/gui/run_experiment_tab.py
+++ b/gui/run_experiment_tab.py
@@ -15,6 +15,10 @@ from com.data_logger import Data_logger
 from gui.plotting import Experiment_plot
 from gui.dialogs import Variables_dialog, Summary_variables_dialog
 from gui.utility import variable_constants, TaskInfo
+try:
+    from config.gui_settings import log_font_size
+except:
+    log_font_size = None
 
 class Run_experiment_tab(QtGui.QWidget):
     '''The run experiment tab is responsible for setting up, running and stopping
@@ -403,7 +407,10 @@ class Subjectbox(QtGui.QGroupBox):
         self.variables_button.setEnabled(False)
         self.log_textbox = QtGui.QTextEdit()
         self.log_textbox.setMinimumHeight(180)
-        self.log_textbox.setFont(QtGui.QFont('Courier', 9))
+        font = QtGui.QFont('Courier')
+        if log_font_size:
+            font.setPixelSize(log_font_size)
+        self.log_textbox.setFont(font)
         self.log_textbox.setReadOnly(True)
 
         self.Vlayout = QtGui.QVBoxLayout(self)

--- a/gui/run_task_tab.py
+++ b/gui/run_task_tab.py
@@ -13,6 +13,10 @@ from config.gui_settings import update_interval
 from gui.dialogs import Variables_dialog
 from gui.plotting import Task_plot
 from gui.utility import init_keyboard_shortcuts,TaskSelectMenu, TaskInfo
+try:
+    from config.gui_settings import log_font_size
+except:
+    log_font_size = None
 
 # Run_task_gui ------------------------------------------------------------------------
 
@@ -146,7 +150,10 @@ class Run_task_tab(QtGui.QWidget):
         # Log text and task plots.
 
         self.log_textbox = QtGui.QTextEdit()
-        self.log_textbox.setFont(QtGui.QFont('Courier', 9))
+        font = QtGui.QFont('Courier')
+        if isinstance(log_font_size,int):
+            font.setPixelSize(log_font_size)
+        self.log_textbox.setFont(font)
         self.log_textbox.setReadOnly(True)
 
         self.task_plot = Task_plot()

--- a/gui/utility.py
+++ b/gui/utility.py
@@ -320,6 +320,7 @@ class TaskSelectMenu(QtGui.QPushButton):
             if self.text() != text:
                 self.callback(text)
                 self.setText(text)
+                self.setAttribute(QtCore.Qt.WA_UnderMouse,False) # without this change, even after an item is clicked/selected, the button will stay highlighted as if still in hover state
         return fxn
     
     def update_menu(self, root_folder):


### PR DESCRIPTION
## Purpose
This commit gives tasks the ability to have custom dialogs for viewing and adjusting variables. 

## Background
For our behavior tasks we have a large number of parameters that we adjust. The default variable dialog can be unwieldy with so many parameters. Scrolling/searching for parameters, and typing in new values can be tedious or error prone.
<img width="940" alt="CleanShot 2021-10-02 at 14 37 58@2x" src="https://user-images.githubusercontent.com/8128628/135728210-81f9bd6a-9467-4f35-b960-99a6e1b6078d.png">

To solve this I ended up making a task-specific variable dialog that provides a better GUI for viewing/adjusting variables. With the custom dialog, we can organize parameters into tabbed pages, and adjust them quickly with spinboxes, radio buttons and checkboxes. Video demo below:

https://user-images.githubusercontent.com/8128628/135728701-af73008d-e155-4a4a-8f74-171b8d19235f.mp4

Our fork of pyControl sort of hacks this feature in, but I thought this would be useful for others so I've tried to standardize the process.

## Changes
I did my best to follow the structure established by James' API code https://github.com/neuromantic99/pyControl/tree/api_dev . 

The user places their custom GUI class in the `gui/user_variable_dialogs/` directory, then in their task file assigns their custom class to `v.custom_variable_dialog`

Custom variable dialog GUIs for multiple tasks can be created more easily by importing/reusing elements from a common `dialog_elements.py` file. So far I've only included a standard variable input (acts exactly like the default variable input) and a spinbox input. Some useful features of the dialog elements to point out:
- the spinboxes have a maximum, minimum, and increment setting. 
- you can add suffixes to the spinboxes so values will say "XX ms" or "XX µL"
- you can add "hints" that appear when you hover over the parameter label
- emojis are fair game for the parameter labels, making finding parameters even faster

I have added an example custom GUI for the `reversal_learning.py` task. You can see the difference below:

![reversal_dialog](https://user-images.githubusercontent.com/8128628/135729320-412daa94-8a09-438a-bfab-c968524f61ba.png)
