### PR TITLE
Unify styling across operating systems

### DIFF
--- a/config/gui_settings.py
+++ b/config/gui_settings.py
@@ -7,3 +7,7 @@ update_interval = 20 # Interval between calls to the GUIs update function (ms).
 event_history_len  = 200  # Length of event history to plot (# events).
 state_history_len  = 100  # Length of state history to plot (# states). 
 analog_history_dur = 12   # Duration of analog signal history to plot (seconds).
+
+# uncomment either or both of the following variables to customize pyControl's font size
+#ui_font_size = 12 	# the font size of UI elements (button text, label text, line edit text, etc.)
+#log_font_size =  12	# the font size of the pyControl data logger 

--- a/gui/GUI_main.py
+++ b/gui/GUI_main.py
@@ -188,6 +188,28 @@ class GUI_main(QtGui.QMainWindow):
 def launch_GUI():
     '''Launch the pyControl GUI.'''
     app = QtGui.QApplication(sys.argv)
+    app.setStyle('Fusion')
+    style = """
+        QPushButton:hover{
+            background-color:CornflowerBlue;
+        }
+        QComboBox:hover{
+            background-color:CornflowerBlue;
+        }
+        QLineEdit[readOnly=\"false\"]:hover{
+            border: 1px solid CornflowerBlue;
+        }
+        QTabBar:tab:hover{
+            color:  #4881ea;
+        }
+        QCheckBox:hover{
+            color:  #4881ea ;
+        }
+        QTableView:item:hover{
+            border: 1px solid CornflowerBlue;
+        }
+    """
+    app.setStyleSheet(style)
     gui_main = GUI_main()
     gui_main.app = app # To allow app functions to be called from GUI.
     sys.excepthook = gui_main.excepthook

--- a/gui/GUI_main.py
+++ b/gui/GUI_main.py
@@ -13,6 +13,11 @@ from gui.configure_experiment_tab import Configure_experiment_tab
 from gui.run_experiment_tab import Run_experiment_tab
 from gui.setups_tab import Setups_tab
 
+try:
+    from config.gui_settings import ui_font_size
+except:
+    ui_font_size = None
+
 # --------------------------------------------------------------------------------
 # GUI_main
 # --------------------------------------------------------------------------------
@@ -210,6 +215,10 @@ def launch_GUI():
         }
     """
     app.setStyleSheet(style)
+    font = QtGui.QFont()
+    if ui_font_size:
+        font.setPixelSize(ui_font_size)
+    app.setFont(font)
     gui_main = GUI_main()
     gui_main.app = app # To allow app functions to be called from GUI.
     sys.excepthook = gui_main.excepthook

--- a/gui/run_experiment_tab.py
+++ b/gui/run_experiment_tab.py
@@ -15,6 +15,10 @@ from com.data_logger import Data_logger
 from gui.plotting import Experiment_plot
 from gui.dialogs import Variables_dialog, Summary_variables_dialog
 from gui.utility import variable_constants, TaskInfo
+try:
+    from config.gui_settings import log_font_size
+except:
+    log_font_size = None
 
 class Run_experiment_tab(QtGui.QWidget):
     '''The run experiment tab is responsible for setting up, running and stopping
@@ -403,7 +407,10 @@ class Subjectbox(QtGui.QGroupBox):
         self.variables_button.setEnabled(False)
         self.log_textbox = QtGui.QTextEdit()
         self.log_textbox.setMinimumHeight(180)
-        self.log_textbox.setFont(QtGui.QFont('Courier', 9))
+        font = QtGui.QFont('Courier')
+        if log_font_size:
+            font.setPixelSize(log_font_size)
+        self.log_textbox.setFont(font)
         self.log_textbox.setReadOnly(True)
 
         self.Vlayout = QtGui.QVBoxLayout(self)

--- a/gui/run_task_tab.py
+++ b/gui/run_task_tab.py
@@ -13,6 +13,10 @@ from config.gui_settings import update_interval
 from gui.dialogs import Variables_dialog
 from gui.plotting import Task_plot
 from gui.utility import init_keyboard_shortcuts,TaskSelectMenu, TaskInfo
+try:
+    from config.gui_settings import log_font_size
+except:
+    log_font_size = None
 
 # Run_task_gui ------------------------------------------------------------------------
 
@@ -146,7 +150,10 @@ class Run_task_tab(QtGui.QWidget):
         # Log text and task plots.
 
         self.log_textbox = QtGui.QTextEdit()
-        self.log_textbox.setFont(QtGui.QFont('Courier', 9))
+        font = QtGui.QFont('Courier')
+        if isinstance(log_font_size,int):
+            font.setPixelSize(log_font_size)
+        self.log_textbox.setFont(font)
         self.log_textbox.setReadOnly(True)
 
         self.task_plot = Task_plot()

--- a/gui/utility.py
+++ b/gui/utility.py
@@ -320,6 +320,7 @@ class TaskSelectMenu(QtGui.QPushButton):
             if self.text() != text:
                 self.callback(text)
                 self.setText(text)
+                self.setAttribute(QtCore.Qt.WA_UnderMouse,False) # without this change, even after an item is clicked/selected, the button will stay highlighted as if still in hover state
         return fxn
     
     def update_menu(self, root_folder):


### PR DESCRIPTION
## Background
The pyQt UI style for Mac isn't the greatest, it tends to waste a lot of space. Fixes can be made, but it would have side effects for window and linux , or would require adding platform specific code which would be a pain to maintain as the project expands. 

The pyQt UI style for windows is pretty good in my opinion, but still varies a good amount depending on what version of Windows you are running. Also, I feel like things get worse each year with usability being sacrificed for aesthetics most of the time. 

I propose changing to Qt's "Fusion" style so the interface is the same regardless of which OS you are using. Although it doesn't look as sleek as Windows 10, I think the "Fusion" style is quite user friendly. Improvements/customizations will be easy to make since there will only be one style to maintain.

## Changes
- switched to Qt's "Fusion" style and added some custom styling for hovering over buttons and such.
- added the ability to adjust font sizes. User simply edits font variables in `gui_settings.py` 

### Windows before (left) and after (right)
<img width="1408" alt="CleanShot 2021-10-04 at 19 58 48@2x" src="https://user-images.githubusercontent.com/8128628/135952685-7692b105-5c94-40de-b265-03b44d2a07f3.png">

### Mac before (left) and after (right)
<img width="1402" alt="CleanShot 2021-10-04 at 20 05 14@2x" src="https://user-images.githubusercontent.com/8128628/135952690-c38a7887-b40c-42c8-88bb-2c4cd3eece96.png">
le