### PR TITLE
changes to run task's  "setup" selection

### DIFF
--- a/gui/run_task_tab.py
+++ b/gui/run_task_tab.py
@@ -53,7 +53,6 @@ class Run_task_tab(QtGui.QWidget):
         self.board_groupbox = QtGui.QGroupBox('Setup')
 
         self.board_select = QtGui.QComboBox()
-        self.board_select.setEditable(True)
         self.board_select.addItems(['No setups found'])
         self.board_select.setSizeAdjustPolicy(0)
         self.connect_button = QtGui.QPushButton('Connect')

--- a/gui/run_task_tab.py
+++ b/gui/run_task_tab.py
@@ -52,10 +52,10 @@ class Run_task_tab(QtGui.QWidget):
 
         self.board_groupbox = QtGui.QGroupBox('Setup')
 
-        self.board_label = QtGui.QLabel('Select:')
         self.board_select = QtGui.QComboBox()
         self.board_select.setEditable(True)
-        self.board_select.setFixedWidth(100)
+        self.board_select.addItems(['No setups found'])
+        self.board_select.setSizeAdjustPolicy(0)
         self.connect_button = QtGui.QPushButton('Connect')
         self.connect_button.setIcon(QtGui.QIcon("gui/icons/connect.svg"))
         self.connect_button.setEnabled(False)
@@ -63,7 +63,6 @@ class Run_task_tab(QtGui.QWidget):
         self.config_button.setIcon(QtGui.QIcon("gui/icons/settings.svg"))
 
         self.boardgroup_layout = QtGui.QHBoxLayout()
-        self.boardgroup_layout.addWidget(self.board_label)
         self.boardgroup_layout.addWidget(self.board_select)
         self.boardgroup_layout.addWidget(self.connect_button)
         self.boardgroup_layout.addWidget(self.config_button)
@@ -222,6 +221,7 @@ class Run_task_tab(QtGui.QWidget):
                 if not self.connected:
                     self.connect_button.setEnabled(True)
             else: # No setups available to connect to.
+                    self.board_select.addItems(['No setups found'])
                     self.connect_button.setEnabled(False)
         if self.GUI_main.available_tasks_changed:
             self.task_select.update_menu(dirs['tasks'])


### PR DESCRIPTION
- "select" label next to a combo box seemed redundant, so I  removed it
- if no setups are found, the combo box now says "No setups found"
- size of combo box now automatically adjusts to width of items, so long setup names won't be cutoff