### PR TITLE
Fix to reveal silent ISR failure

### DIFF
--- a/com/pycboard.py
+++ b/com/pycboard.py
@@ -395,6 +395,8 @@ class Pycboard(Pyboard):
                     error_message = data_err[:-3].decode()
                     new_data.append(('!', error_message))                
                 break
+            else:
+                print(new_byte.decode("utf-8"),end='')
         if new_data and self.data_logger:
             self.data_logger.process_data(new_data)
         if error_message:


### PR DESCRIPTION
I was having a lot of trouble debugging code. I was inheriting the Analog_input class and trying to create a device that reads a distance sensor over I2C. 

My difficulties seemed to be in the same vein as described in this pyControl forum [high frequency events thread](https://groups.google.com/g/pycontrol/c/6MgksnyZCVs). Like @AtMostafa, my task would continue run but the analog plotting was not working and I was getting no error messages.

This commit prints out any bytes that get read, but not processed.
After adding the print statement it ended up revealing this in the terminal running pyControl:

```
uncaught exception in Timer(14) interrupt handler
MemoryError:
```

I was able to fix my interrupt service routine and get everything working.

I think this addresses #18 



