### PR TITLE
Fix custom dialog editor "add" button crash

### DIFF
--- a/gui/configure_experiment_tab.py
+++ b/gui/configure_experiment_tab.py
@@ -393,7 +393,7 @@ class SubjectsTable(QtGui.QTableWidget):
         remove_button.setIcon(QtGui.QIcon("gui/icons/remove.svg"))
         ind = QtCore.QPersistentModelIndex(self.model().index(self.n_subjects, 2))
         remove_button.clicked.connect(lambda :self.remove_subject(ind.row()))
-        add_button = QtGui.QPushButton('add')
+        add_button = QtGui.QPushButton('   add   ')
         add_button.setIcon(QtGui.QIcon("gui/icons/add.svg"))
         add_button.clicked.connect(self.add_subject)
         run_checkbox = TableCheckbox()

--- a/gui/custom_variables_dialog.py
+++ b/gui/custom_variables_dialog.py
@@ -584,7 +584,7 @@ class Variables_dialog_editor(QtGui.QDialog):
 
 
 class Variable_row:
-    def __init__(self, parent, var_name=None, row_data=None):
+    def __init__(self, parent, var_name=False, row_data=False):
         self.parent = parent
         # buttons
         self.up_button = QtGui.QPushButton("⬆️")
@@ -676,19 +676,20 @@ class Variables_table(QtGui.QTableWidget):
         self.setColumnWidth(8, 40)
         self.setColumnWidth(9, 150)
 
-        self.add_button = QtGui.QPushButton("   add   ")
-        self.add_button.setIcon(QtGui.QIcon("gui/icons/add.svg"))
-        self.add_button.clicked.connect(self.add_row)
-
         self.n_variables = 0
         self.clear_label_flag = None
         if data and data["ordered_inputs"]:
             for element in data["ordered_inputs"]:
                 self.add_row(element, data[element])
+            # after done loading control rows, insert another row with an "add" button
+            add_button = QtGui.QPushButton("   add   ")
+            add_button.setIcon(QtGui.QIcon("gui/icons/add.svg"))
+            add_button.clicked.connect(self.add_row)
+            self.setCellWidget(self.n_variables, 10, add_button)
         else:
             self.add_row()
 
-    def add_row(self, varname=None, row_dict=None):
+    def add_row(self, varname=False, row_dict=False):
         # populate row with widgets
         new_widgets = Variable_row(self, varname, row_dict)
         new_widgets.put_into_table(row_index=self.n_variables)
@@ -696,9 +697,13 @@ class Variables_table(QtGui.QTableWidget):
         # connect buttons to functions
         self.connect_buttons(self.n_variables)
 
-        # insert another row and shift down "add" button
+        # insert another row with an "add" button
         self.insertRow(self.n_variables + 1)
-        self.setCellWidget(self.n_variables + 1, 10, self.add_button)
+        if not varname:
+            add_button = QtGui.QPushButton("   add   ")
+            add_button.setIcon(QtGui.QIcon("gui/icons/add.svg"))
+            add_button.clicked.connect(self.add_row)
+            self.setCellWidget(self.n_variables + 1, 10, add_button)
 
         self.n_variables += 1
         self.update_available()


### PR DESCRIPTION
There is a major bug for the custom dialog editor, introduced in c74916061409544a4b618808657bd8b288938e56 . That commit was intended to fix a bug where extra add buttons were getting added underneath the table when an existing custom dialog was being loaded into the custom dialog editor (see video below).

https://user-images.githubusercontent.com/8128628/163068236-cdfcdc7f-f13e-4c6c-8567-1e6db7e93e45.mp4


The hidden buttons problem was fixed, but unfortunately a new bug was introduced. If there are no rows of existing controls loaded into the editor (like when someone is creating a new custom dialog, or adding a new tab to an existing custom dialog), then the add button will add another row but then any further interaction with the editor will cause the entire program to crash (see video below).

https://user-images.githubusercontent.com/8128628/163069620-0e293036-4134-4b64-a015-fe73d722a6c5.mp4

This pull request fixes the crash