### PR TITLE
Upgrade to PyQt6

### DIFF
--- a/config/user_variable_dialogs/blinker_gui_from_py.py
+++ b/config/user_variable_dialogs/blinker_gui_from_py.py
@@ -5,36 +5,36 @@ from pyqtgraph.Qt import QtGui, QtCore
 from gui.custom_variables_dialog import Slider_var, Spin_var
 
 # Custom Variable dialog
-class Custom_variables_dialog(QtGui.QDialog):
+class Custom_variables_dialog(QtWidgets.QDialog):
     # Dialog for setting and getting task variables.
     def __init__(self, parent, board):
-        super(QtGui.QDialog, self).__init__(parent)
+        super(QtWidgets.QDialog, self).__init__(parent)
         self.setWindowTitle("Blink Variable GUI")
-        self.layout = QtGui.QVBoxLayout(self)
+        self.layout = QtWidgets.QVBoxLayout(self)
         self.variables_grid = Variables_grid(self, board)
         self.layout.addWidget(self.variables_grid)
         self.layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(self.layout)
 
 
-class Variables_grid(QtGui.QWidget):
+class Variables_grid(QtWidgets.QWidget):
     def __init__(self, parent, board):
-        super(QtGui.QWidget, self).__init__(parent)
+        super(QtWidgets.QWidget, self).__init__(parent)
         variables = board.sm_info["variables"]
-        self.grid_layout = QtGui.QGridLayout()
+        self.grid_layout = QtWidgets.QGridLayout()
         initial_variables_dict = {v_name: v_value_str for (v_name, v_value_str) in sorted(variables.items())}
         self.variables_gui = Variables_gui(self, self.grid_layout, board, initial_variables_dict)
         self.setLayout(self.grid_layout)
 
 
-class Variables_gui(QtGui.QWidget):
+class Variables_gui(QtWidgets.QWidget):
     def __init__(self, parent, grid_layout, board, init_vars):
-        super(QtGui.QWidget, self).__init__(parent)
+        super(QtWidgets.QWidget, self).__init__(parent)
         self.board = board
 
         # create widgets
-        widget = QtGui.QWidget()
-        layout = QtGui.QGridLayout()
+        widget = QtWidgets.QWidget()
+        layout = QtWidgets.QGridLayout()
         row = 0
 
         # blink rate controls
@@ -44,29 +44,29 @@ class Variables_gui(QtGui.QWidget):
         self.blink_rate.setBoard(board)
         self.blink_rate.add_to_grid(layout, row)
         row += 1
-        self.min_btn = QtGui.QPushButton("min")
-        self.mid_btn = QtGui.QPushButton("50%")
-        self.max_btn = QtGui.QPushButton("max")
+        self.min_btn = QtWidgets.QPushButton("min")
+        self.mid_btn = QtWidgets.QPushButton("50%")
+        self.max_btn = QtWidgets.QPushButton("max")
         for col,btn in enumerate([self.min_btn,self.mid_btn,self.max_btn]):
-            layout.addWidget(btn, row,col, QtCore.Qt.AlignCenter)
-            btn.setFocusPolicy(QtCore.Qt.NoFocus)
+            layout.addWidget(btn, row,col, QtCore.Qt.AlignmentFlag.AlignCenter)
+            btn.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
             btn.setMaximumWidth(70)
         row += 1
 
         # separator
-        layout.addWidget(QtGui.QLabel("<hr>"), row, 0, 1, 4)
+        layout.addWidget(QtWidgets.QLabel("<hr>"), row, 0, 1, 4)
         row += 1
 
         # radio buttons
         red_is_enabled = eval(init_vars["red_enabled"])
         green_is_enabled = eval(init_vars["green_enabled"])
         self.both_radio = QtGui.QRadioButton()
-        self.both_lbl = QtGui.QLabel("🔴Both🟢")
+        self.both_lbl = QtWidgets.QLabel("🔴Both🟢")
         self.red_radio = QtGui.QRadioButton()
-        self.red_lbl = QtGui.QLabel("Red")
+        self.red_lbl = QtWidgets.QLabel("Red")
         self.red_lbl.setStyleSheet("border:3px solid red;background:red;border-radius:3px;")  # you can use css styling
         self.green_radio = QtGui.QRadioButton()
-        self.green_lbl = QtGui.QLabel("Green")
+        self.green_lbl = QtWidgets.QLabel("Green")
         self.green_lbl.setStyleSheet("border-radius:3px;border:3px solid green;background:green;color:white")
         if red_is_enabled and green_is_enabled:
             self.both_radio.setChecked(True)
@@ -84,13 +84,13 @@ class Variables_gui(QtGui.QWidget):
                 self.red_radio.setChecked(False)
                 self.green_radio.setChecked(False)
 
-        layout.addWidget(self.both_lbl, row, 0, QtCore.Qt.AlignCenter)
-        layout.addWidget(self.red_lbl, row, 1, QtCore.Qt.AlignCenter)
-        layout.addWidget(self.green_lbl, row, 2, QtCore.Qt.AlignCenter)
+        layout.addWidget(self.both_lbl, row, 0, QtCore.Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.red_lbl, row, 1, QtCore.Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.green_lbl, row, 2, QtCore.Qt.AlignmentFlag.AlignCenter)
         row += 1
-        layout.addWidget(self.both_radio, row, 0, QtCore.Qt.AlignCenter)
-        layout.addWidget(self.red_radio, row, 1, QtCore.Qt.AlignCenter)
-        layout.addWidget(self.green_radio, row, 2, QtCore.Qt.AlignCenter)
+        layout.addWidget(self.both_radio, row, 0, QtCore.Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.red_radio, row, 1, QtCore.Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.green_radio, row, 2, QtCore.Qt.AlignmentFlag.AlignCenter)
         row += 1
 
         # counts
@@ -104,14 +104,14 @@ class Variables_gui(QtGui.QWidget):
         row += 1
 
         # image
-        self.picture = QtGui.QLabel()
+        self.picture = QtWidgets.QLabel()
         image = QtGui.QPixmap("config/user_variable_dialogs/example_image.png")
         self.picture.setPixmap(image)
         layout.addWidget(self.picture, row, 0, 1, 4)
         row += 1
 
         # gif
-        self.gif = QtGui.QLabel()
+        self.gif = QtWidgets.QLabel()
         self.movie = QtGui.QMovie("config/user_variable_dialogs/example_movie.gif")
         self.gif.setMovie(self.movie)
         self.movie.start()
@@ -120,7 +120,7 @@ class Variables_gui(QtGui.QWidget):
 
         layout.setRowStretch(row, 1)
         widget.setLayout(layout)
-        grid_layout.addWidget(widget, 0, 0, QtCore.Qt.AlignLeft)
+        grid_layout.addWidget(widget, 0, 0, QtCore.Qt.AlignmentFlag.AlignLeft)
 
         # connect some buttons to functions
         self.min_btn.clicked.connect(self.slide_to_min)

--- a/config/user_variable_dialogs/blinker_gui_from_py.py
+++ b/config/user_variable_dialogs/blinker_gui_from_py.py
@@ -60,12 +60,12 @@ class Variables_gui(QtWidgets.QWidget):
         # radio buttons
         red_is_enabled = eval(init_vars["red_enabled"])
         green_is_enabled = eval(init_vars["green_enabled"])
-        self.both_radio = QtGui.QRadioButton()
+        self.both_radio = QtWidgets.QRadioButton()
         self.both_lbl = QtWidgets.QLabel("🔴Both🟢")
-        self.red_radio = QtGui.QRadioButton()
+        self.red_radio = QtWidgets.QRadioButton()
         self.red_lbl = QtWidgets.QLabel("Red")
         self.red_lbl.setStyleSheet("border:3px solid red;background:red;border-radius:3px;")  # you can use css styling
-        self.green_radio = QtGui.QRadioButton()
+        self.green_radio = QtWidgets.QRadioButton()
         self.green_lbl = QtWidgets.QLabel("Green")
         self.green_lbl.setStyleSheet("border-radius:3px;border:3px solid green;background:green;color:white")
         if red_is_enabled and green_is_enabled:
@@ -142,7 +142,7 @@ class Variables_gui(QtWidgets.QWidget):
         self.red_count.setEnabled(red_val)  # enable or disable control
         self.green_count.setEnabled(green_val)
         if not self.board.framework_running:  # Value returned later.
-            msg = QtGui.QMessageBox()
+            msg = QtWidgets.QMessageBox()
             msg.setText("Variable Changed")
             msg.exec()
 

--- a/gui/GUI_main.py
+++ b/gui/GUI_main.py
@@ -5,7 +5,7 @@ import traceback
 import logging
 
 from serial.tools import list_ports
-from pyqtgraph.Qt import QtGui, QtCore
+from pyqtgraph.Qt import QtGui, QtCore, QtWidgets
 
 from config.paths import dirs
 from config.gui_settings import  VERSION, ui_font_size
@@ -22,9 +22,9 @@ if os.name == 'nt': # Needed on windows to get taskbar icon to display correctly
 # GUI_main
 # --------------------------------------------------------------------------------
 
-class GUI_main(QtGui.QMainWindow):
+class GUI_main(QtWidgets.QMainWindow):
  
-    def __init__(self):
+    def __init__(self,app):
         super().__init__()
         self.setWindowTitle('pyControl v{}'.format(VERSION))
         self.setGeometry(10, 30, 700, 800) # Left, top, width, height.
@@ -39,7 +39,7 @@ class GUI_main(QtGui.QMainWindow):
         self.available_ports_changed = False
         self.data_dir_changed = False
         self.current_tab_ind = 0 # Which tab is currently selected.
-        self.app = None # Overwritten with QtGui.QApplication instance in main.
+        self.app = app
 
         # Dialogs.
 
@@ -48,11 +48,11 @@ class GUI_main(QtGui.QMainWindow):
         self.paths_dialog = Paths_dialog(parent=self)
 
         # Widgets.
-        self.tab_widget = QtGui.QTabWidget(self)
+        self.tab_widget = QtWidgets.QTabWidget(self)
         self.setCentralWidget(self.tab_widget)
 
         self.run_task_tab = Run_task_tab(self)  
-        self.experiments_tab = QtGui.QStackedWidget(self)
+        self.experiments_tab = QtWidgets.QStackedWidget(self)
         self.setups_tab = Setups_tab(self)
 
         self.configure_experiment_tab = Configure_experiment_tab(self)
@@ -192,13 +192,12 @@ class GUI_main(QtGui.QMainWindow):
 
 def launch_GUI():
     '''Launch the pyControl GUI.'''
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     app.setStyle('Fusion')
     app.setWindowIcon(QtGui.QIcon("gui/icons/logo.svg"))
     font = QtGui.QFont()
     font.setPixelSize(ui_font_size)
     app.setFont(font)
-    gui_main = GUI_main()
-    gui_main.app = app # To allow app functions to be called from GUI.
+    gui_main = GUI_main(app)
     sys.excepthook = gui_main.excepthook
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/gui/configure_experiment_tab.py
+++ b/gui/configure_experiment_tab.py
@@ -11,12 +11,12 @@ from gui.utility import TableCheckbox, cbox_update_options, cbox_set_item, null_
 # Experiments_tab
 # --------------------------------------------------------------------------------
 
-class Configure_experiment_tab(QtGui.QWidget):
+class Configure_experiment_tab(QtWidgets.QWidget):
     '''The configure experiment tab is used to specify an experiment, i.e. a 
     set of subjects run on a given task on a set of setups.'''
 
     def __init__(self, parent=None):
-        super(QtGui.QWidget, self).__init__(parent)
+        super(QtWidgets.QWidget, self).__init__(parent)
 
         # Variables
         self.GUI_main = self.parent()
@@ -25,37 +25,37 @@ class Configure_experiment_tab(QtGui.QWidget):
         self.saved_exp_dict = {}   # Dict of last saved/loaded experiment.
 
         # Experiment Groupbox
-        self.experiment_groupbox = QtGui.QGroupBox('Experiment')
-        self.expbox_Vlayout = QtGui.QVBoxLayout(self.experiment_groupbox)
-        self.expbox_Hlayout_1 = QtGui.QHBoxLayout()
-        self.separator = QtGui.QLabel("<hr>")
-        self.expbox_Hlayout_2 = QtGui.QHBoxLayout()
-        self.expbox_Hlayout_3 = QtGui.QHBoxLayout()
+        self.experiment_groupbox = QtWidgets.QGroupBox('Experiment')
+        self.expbox_Vlayout = QtWidgets.QVBoxLayout(self.experiment_groupbox)
+        self.expbox_Hlayout_1 = QtWidgets.QHBoxLayout()
+        self.separator = QtWidgets.QLabel("<hr>")
+        self.expbox_Hlayout_2 = QtWidgets.QHBoxLayout()
+        self.expbox_Hlayout_3 = QtWidgets.QHBoxLayout()
         self.expbox_Vlayout.addLayout(self.expbox_Hlayout_1)
         self.expbox_Vlayout.addWidget(self.separator)
         self.expbox_Vlayout.addLayout(self.expbox_Hlayout_2)
         self.expbox_Vlayout.addLayout(self.expbox_Hlayout_3)
 
-        self.experiment_select = QtGui.QComboBox()
+        self.experiment_select = QtWidgets.QComboBox()
 
-        self.run_button = QtGui.QPushButton('Run')
+        self.run_button = QtWidgets.QPushButton('Run')
         self.run_button.setIcon(QtGui.QIcon("gui/icons/run.svg"))
-        self.new_button = QtGui.QPushButton('New')
+        self.new_button = QtWidgets.QPushButton('New')
         self.new_button.setIcon(QtGui.QIcon("gui/icons/add.svg"))
-        self.delete_button = QtGui.QPushButton('Delete')
+        self.delete_button = QtWidgets.QPushButton('Delete')
         self.delete_button.setIcon(QtGui.QIcon("gui/icons/delete.svg"))
-        self.save_button = QtGui.QPushButton('Save')
+        self.save_button = QtWidgets.QPushButton('Save')
         self.save_button.setIcon(QtGui.QIcon("gui/icons/save.svg"))
         self.save_button.setEnabled(False)
-        self.name_label = QtGui.QLabel('Experiment name:')
-        self.name_text = QtGui.QLineEdit()
-        self.task_label = QtGui.QLabel('Task:')
+        self.name_label = QtWidgets.QLabel('Experiment name:')
+        self.name_text = QtWidgets.QLineEdit()
+        self.task_label = QtWidgets.QLabel('Task:')
         self.task_select = TaskSelectMenu('select task')
-        self.hardware_test_label = QtGui.QLabel('Hardware test:')
+        self.hardware_test_label = QtWidgets.QLabel('Hardware test:')
         self.hardware_test_select = TaskSelectMenu('no hardware test',add_default=True)
-        self.data_dir_label = QtGui.QLabel('Data directory:')
-        self.data_dir_text = QtGui.QLineEdit(dirs['data'])
-        self.data_dir_button = QtGui.QPushButton('')
+        self.data_dir_label = QtWidgets.QLabel('Data directory:')
+        self.data_dir_text = QtWidgets.QLineEdit(dirs['data'])
+        self.data_dir_button = QtWidgets.QPushButton('')
         self.data_dir_button.setIcon(QtGui.QIcon("gui/icons/folder.svg"))
         self.data_dir_button.setFixedWidth(30)
 
@@ -78,8 +78,8 @@ class Configure_experiment_tab(QtGui.QWidget):
         self.expbox_Hlayout_3.setStretchFactor(self.data_dir_text, 1)
 
         # Subjects Groupbox
-        self.subjects_groupbox = QtGui.QGroupBox('Subjects')
-        self.subjectsbox_layout = QtGui.QGridLayout(self.subjects_groupbox)
+        self.subjects_groupbox = QtWidgets.QGroupBox('Subjects')
+        self.subjectsbox_layout = QtWidgets.QGridLayout(self.subjects_groupbox)
         self.subset_warning_checkbox = QtWidgets.QCheckBox('Warn me if any subjects will not be run')
         self.subset_warning_checkbox.setChecked(True)
         self.subjectsbox_layout.addWidget(self.subset_warning_checkbox,0,0)
@@ -88,8 +88,8 @@ class Configure_experiment_tab(QtGui.QWidget):
         self.subjectsbox_layout.setColumnStretch(1,1)
 
         # Variables Groupbox
-        self.variables_groupbox = QtGui.QGroupBox('Variables')
-        self.variablesbox_layout = QtGui.QHBoxLayout(self.variables_groupbox)
+        self.variables_groupbox = QtWidgets.QGroupBox('Variables')
+        self.variablesbox_layout = QtWidgets.QHBoxLayout(self.variables_groupbox)
         self.variables_table = VariablesTable(self)
         self.task_select.set_callback(self.variables_table.task_changed)
         self.variablesbox_layout.addWidget(self.variables_table)
@@ -101,7 +101,7 @@ class Configure_experiment_tab(QtGui.QWidget):
         self.name_text.textChanged.connect(self.name_edited)
         self.data_dir_text.textEdited.connect(lambda: setattr(self, 'custom_dir', True))
         self.data_dir_button.clicked.connect(self.select_data_dir)
-        self.experiment_select.activated[str].connect(self.experiment_changed)
+        self.experiment_select.textActivated[str].connect(self.experiment_changed)
         self.new_button.clicked.connect(lambda: self.new_experiment(dialog=True))
         self.delete_button.clicked.connect(self.delete_experiment)
         self.save_button.clicked.connect(self.save_experiment)
@@ -114,7 +114,7 @@ class Configure_experiment_tab(QtGui.QWidget):
         init_keyboard_shortcuts(self, shortcut_dict)
 
         # Main layout
-        self.vertical_layout = QtGui.QVBoxLayout(self)
+        self.vertical_layout = QtWidgets.QVBoxLayout(self)
         self.vertical_layout.addWidget(self.experiment_groupbox)
         self.vertical_layout.addWidget(self.subjects_groupbox)
         self.vertical_layout.addWidget(self.variables_groupbox)
@@ -191,8 +191,8 @@ class Configure_experiment_tab(QtGui.QWidget):
         if os.path.exists(exp_path):
             reply = QtGui.QMessageBox.question(self, 'Delete experiment', 
                 "Delete experiment '{}'".format(self.name_text.text()),
-                    QtGui.QMessageBox.Yes | QtGui.QMessageBox.Cancel)
-            if reply == QtGui.QMessageBox.Yes:
+                    QtGui.QMessageBox.StandardButton.Yes | QtGui.QMessageBox.StandardButton.Cancel)
+            if reply == QtGui.QMessageBox.StandardButton.Yes:
                 self.new_experiment(dialog=False)
                 os.remove(exp_path)
 
@@ -222,8 +222,8 @@ class Configure_experiment_tab(QtGui.QWidget):
         if os.path.exists(exp_path) and (exp_path != self.saved_exp_path):
             reply = QtGui.QMessageBox.question(self, 'Replace file', 
                 "File '{}' already exists, do you want to replace it?".format(file_name),
-                QtGui.QMessageBox.Yes | QtGui.QMessageBox.No)
-            if reply == QtGui.QMessageBox.No:
+                QtGui.QMessageBox.StandardButton.Yes | QtGui.QMessageBox.StandardButton.No)
+            if reply == QtGui.QMessageBox.StandardButton.No:
                 return False
         with open(exp_path,'w') as exp_file:
             exp_file.write(json.dumps(experiment, sort_keys=True, indent=4))
@@ -342,27 +342,27 @@ class Configure_experiment_tab(QtGui.QWidget):
         else:
             dialog_text = 'Experiment edited, save experiment?'
         reply = QtGui.QMessageBox.question(self, 'Save experiment', dialog_text,
-            QtGui.QMessageBox.Yes | QtGui.QMessageBox.No | QtGui.QMessageBox.Cancel)
-        if reply == QtGui.QMessageBox.Yes:
+            QtGui.QMessageBox.StandardButton.Yes | QtGui.QMessageBox.StandardButton.No | QtGui.QMessageBox.StandardButton.Cancel)
+        if reply == QtGui.QMessageBox.StandardButton.Yes:
             was_saved = self.save_experiment(from_dialog=True)
             if not was_saved:
                 invalid_run_experiment_dialog(self, "Failed to save experiment")
                 return False
-        elif reply == QtGui.QMessageBox.Cancel:
+        elif reply == QtGui.QMessageBox.StandardButton.Cancel:
             return False
         return True
 
 # ---------------------------------------------------------------------------------
 
-class SubjectsTable(QtGui.QTableWidget):
+class SubjectsTable(QtWidgets.QTableWidget):
     '''Table for specifying the setups and subjects used in experiment. '''
 
     def __init__(self, parent=None):
-        super(QtGui.QTableWidget, self).__init__(1,4, parent=parent)
+        super(QtWidgets.QTableWidget, self).__init__(1,4, parent=parent)
         self.setHorizontalHeaderLabels(['Run','Setup', 'Subject', ''])
-        self.horizontalHeader().setResizeMode(1, QtGui.QHeaderView.Stretch)
-        self.horizontalHeader().setResizeMode(2, QtGui.QHeaderView.Stretch)
-        self.horizontalHeader().setResizeMode(3, QtGui.QHeaderView.ResizeToContents)
+        self.horizontalHeader().setSectionResizeMode(1, QtWidgets.QHeaderView.ResizeMode.Stretch)
+        self.horizontalHeader().setSectionResizeMode(2, QtWidgets.QHeaderView.ResizeMode.Stretch)
+        self.horizontalHeader().setSectionResizeMode(3, QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
         self.verticalHeader().setVisible(False)
         self.cellChanged.connect(self.cell_changed)
         self.all_setups = set([])
@@ -388,18 +388,18 @@ class SubjectsTable(QtGui.QTableWidget):
 
     def add_subject(self, setup=None, subject=None, do_run=None):
         '''Add row to table allowing extra subject to be specified.'''
-        setup_cbox = QtGui.QComboBox()
+        setup_cbox = QtWidgets.QComboBox()
         setup_cbox.addItems(self.available_setups if self.available_setups
                             else ['select setup'])
         if self.unallocated_setups:
             setup_cbox.setCurrentIndex(self.available_setups.index(
                                        self.unallocated_setups[0]))
         setup_cbox.activated.connect(self.update_available_setups)
-        remove_button = QtGui.QPushButton('remove')
+        remove_button = QtWidgets.QPushButton('remove')
         remove_button.setIcon(QtGui.QIcon("gui/icons/remove.svg"))
         ind = QtCore.QPersistentModelIndex(self.model().index(self.n_subjects, 2))
         remove_button.clicked.connect(lambda :self.remove_subject(ind.row()))
-        add_button = QtGui.QPushButton('   add   ')
+        add_button = QtWidgets.QPushButton('   add   ')
         add_button.setIcon(QtGui.QIcon("gui/icons/add.svg"))
         add_button.clicked.connect(self.add_subject)
         run_checkbox = TableCheckbox()
@@ -415,7 +415,7 @@ class SubjectsTable(QtGui.QTableWidget):
         if setup:
             cbox_set_item(setup_cbox, setup)
         if subject:
-            subject_item = QtGui.QTableWidgetItem()
+            subject_item = QtWidgets.QTableWidgetItem()
             subject_item.setText(subject)
             self.setItem(self.n_subjects, 2, subject_item)
         self.n_subjects += 1
@@ -476,18 +476,18 @@ class SubjectsTable(QtGui.QTableWidget):
 
 # -------------------------------------------------------------------------------
 
-class VariablesTable(QtGui.QTableWidget):
+class VariablesTable(QtWidgets.QTableWidget):
     '''Class for specifying task variables that are set to non-default values.'''
 
     def __init__(self, parent=None):
-        super(QtGui.QTableWidget, self).__init__(1,6, parent=parent)
+        super(QtWidgets.QTableWidget, self).__init__(1,6, parent=parent)
         self.subjects_table = self.parent().subjects_table
         self.setHorizontalHeaderLabels(['Variable', 'Subject', 'Value', 'Persistent','Summary',''])
-        self.horizontalHeader().setResizeMode(0, QtGui.QHeaderView.Stretch)
-        self.horizontalHeader().setResizeMode(2, QtGui.QHeaderView.Stretch)
-        self.horizontalHeader().setResizeMode(5, QtGui.QHeaderView.ResizeToContents)
+        self.horizontalHeader().setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeMode.Stretch)
+        self.horizontalHeader().setSectionResizeMode(2, QtWidgets.QHeaderView.ResizeMode.Stretch)
+        self.horizontalHeader().setSectionResizeMode(5, QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
         self.verticalHeader().setVisible(False)
-        add_button = QtGui.QPushButton('   add   ')
+        add_button = QtWidgets.QPushButton('   add   ')
         add_button.setIcon(QtGui.QIcon("gui/icons/add.svg"))
         add_button.clicked.connect(self.add_variable)
         self.setCellWidget(0,5, add_button)
@@ -505,17 +505,17 @@ class VariablesTable(QtGui.QTableWidget):
 
     def add_variable(self, var_dict=None):
         '''Add a row to the variables table.'''
-        variable_cbox = QtGui.QComboBox()
+        variable_cbox = QtWidgets.QComboBox()
         variable_cbox.activated.connect(self.update_available)
-        subject_cbox = QtGui.QComboBox()
+        subject_cbox = QtWidgets.QComboBox()
         subject_cbox.activated.connect(self.update_available)
         persistent = TableCheckbox()
         summary    = TableCheckbox()
-        remove_button = QtGui.QPushButton('remove')
+        remove_button = QtWidgets.QPushButton('remove')
         ind = QtCore.QPersistentModelIndex(self.model().index(self.n_variables, 2))
         remove_button.clicked.connect(lambda :self.remove_variable(ind.row()))
         remove_button.setIcon(QtGui.QIcon("gui/icons/remove.svg"))
-        add_button = QtGui.QPushButton('   add   ')
+        add_button = QtWidgets.QPushButton('   add   ')
         add_button.setIcon(QtGui.QIcon("gui/icons/add.svg"))
         add_button.clicked.connect(self.add_variable)
         self.insertRow(self.n_variables+1)
@@ -528,7 +528,7 @@ class VariablesTable(QtGui.QTableWidget):
         if var_dict: # Set cell values from provided dictionary.
             variable_cbox.addItems([var_dict['name']])
             subject_cbox.addItems([var_dict['subject']])
-            value_item = QtGui.QTableWidgetItem()
+            value_item = QtWidgets.QTableWidgetItem()
             value_item.setText(var_dict['value'])
             self.setItem(self.n_variables, 2, value_item)
             persistent.setChecked(var_dict['persistent'])

--- a/gui/configure_experiment_tab.py
+++ b/gui/configure_experiment_tab.py
@@ -127,7 +127,7 @@ class Configure_experiment_tab(QtWidgets.QWidget):
             self.data_dir_text.setText(os.path.join(dirs['data'], self.name_text.text()))
 
     def select_data_dir(self):
-        new_path = QtGui.QFileDialog.getExistingDirectory(self, 'Select data folder', dirs['data'])
+        new_path = QtWidgets.QFileDialog.getExistingDirectory(self, 'Select data folder', dirs['data'])
         if new_path:
             self.data_dir_text.setText(new_path)
             self.custom_dir = True
@@ -189,10 +189,10 @@ class Configure_experiment_tab(QtWidgets.QWidget):
         '''Delete an experiment file after dialog to confirm deletion.'''
         exp_path = os.path.join(dirs['experiments'], self.name_text.text()+'.pcx')
         if os.path.exists(exp_path):
-            reply = QtGui.QMessageBox.question(self, 'Delete experiment', 
+            reply = QtWidgets.QMessageBox.question(self, 'Delete experiment', 
                 "Delete experiment '{}'".format(self.name_text.text()),
-                    QtGui.QMessageBox.StandardButton.Yes | QtGui.QMessageBox.StandardButton.Cancel)
-            if reply == QtGui.QMessageBox.StandardButton.Yes:
+                    QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.Cancel)
+            if reply == QtWidgets.QMessageBox.StandardButton.Yes:
                 self.new_experiment(dialog=False)
                 os.remove(exp_path)
 
@@ -220,10 +220,10 @@ class Configure_experiment_tab(QtWidgets.QWidget):
         file_name = self.name_text.text()+'.pcx'
         exp_path = os.path.join(dirs['experiments'], file_name)
         if os.path.exists(exp_path) and (exp_path != self.saved_exp_path):
-            reply = QtGui.QMessageBox.question(self, 'Replace file', 
+            reply = QtWidgets.QMessageBox.question(self, 'Replace file', 
                 "File '{}' already exists, do you want to replace it?".format(file_name),
-                QtGui.QMessageBox.StandardButton.Yes | QtGui.QMessageBox.StandardButton.No)
-            if reply == QtGui.QMessageBox.StandardButton.No:
+                QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No)
+            if reply == QtWidgets.QMessageBox.StandardButton.No:
                 return False
         with open(exp_path,'w') as exp_file:
             exp_file.write(json.dumps(experiment, sort_keys=True, indent=4))
@@ -341,14 +341,14 @@ class Configure_experiment_tab(QtWidgets.QWidget):
             dialog_text = 'Experiment not saved, save experiment?'
         else:
             dialog_text = 'Experiment edited, save experiment?'
-        reply = QtGui.QMessageBox.question(self, 'Save experiment', dialog_text,
-            QtGui.QMessageBox.StandardButton.Yes | QtGui.QMessageBox.StandardButton.No | QtGui.QMessageBox.StandardButton.Cancel)
-        if reply == QtGui.QMessageBox.StandardButton.Yes:
+        reply = QtWidgets.QMessageBox.question(self, 'Save experiment', dialog_text,
+            QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No | QtWidgets.QMessageBox.StandardButton.Cancel)
+        if reply == QtWidgets.QMessageBox.StandardButton.Yes:
             was_saved = self.save_experiment(from_dialog=True)
             if not was_saved:
                 invalid_run_experiment_dialog(self, "Failed to save experiment")
                 return False
-        elif reply == QtGui.QMessageBox.StandardButton.Cancel:
+        elif reply == QtWidgets.QMessageBox.StandardButton.Cancel:
             return False
         return True
 

--- a/gui/custom_variables_dialog.py
+++ b/gui/custom_variables_dialog.py
@@ -18,9 +18,9 @@ class Spin_var:
         self.varname = varname
 
         if isinstance(spin_min, float) or isinstance(spin_max, float) or isinstance(step, float):
-            self.spn = QtGui.QDoubleSpinBox()
+            self.spn = QtWidgets.QDoubleSpinBox()
         else:
-            self.spn = QtGui.QSpinBox()
+            self.spn = QtWidgets.QSpinBox()
 
         self.spn.setRange(spin_min, spin_max)
         self.spn.setValue(eval(init_var_dict[varname]))
@@ -68,7 +68,7 @@ class Spin_var:
         if self.board.framework_running:  # Value returned later.
             QtCore.QTimer.singleShot(200, self.reload)
         else:  # Value returned immediately.
-            msg = QtGui.QMessageBox()
+            msg = QtWidgets.QMessageBox()
             msg.setText("Variable Changed")
             msg.exec()
             self.spn.setValue(self.board.get_variable(self.varname))
@@ -160,7 +160,7 @@ class Standard_var:
         if self.board.framework_running:  # Value returned later.
             QtCore.QTimer.singleShot(200, self.reload)
         else:  # Value returned immediately.
-            msg = QtGui.QMessageBox()
+            msg = QtWidgets.QMessageBox()
             msg.setText("Variable Changed")
             msg.exec()
             self.line_edit.setText(str(self.board.get_variable(self.varname)))
@@ -199,7 +199,7 @@ class Checkbox_var:
     def set(self):
         self.board.set_variable(self.varname, self.checkbox.isChecked())
         if not self.board.framework_running:  # Value returned later.
-            msg = QtGui.QMessageBox()
+            msg = QtWidgets.QMessageBox()
             msg.setText("Variable Changed")
             msg.exec()
 
@@ -288,7 +288,7 @@ class Slider_var:
     def set(self):
         self.board.set_variable(self.varname, self.slider.value())
         if not self.board.framework_running:  # Value returned later.
-            msg = QtGui.QMessageBox()
+            msg = QtWidgets.QMessageBox()
             msg.setText("Variable Changed")
             msg.exec()
 
@@ -599,13 +599,13 @@ class Variables_dialog_editor(QtWidgets.QDialog):
 
     def remove_tab(self):
         if len(self.tables) > 1:
-            reply = QtGui.QMessageBox.question(
+            reply = QtWidgets.QMessageBox.question(
                 self,
                 "Remove tab",
                 f'Are you sure you want to remove "{self.tab_title_edit.text()}"?',
-                QtGui.QMessageBox.Yes | QtGui.QMessageBox.Cancel,
+                QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.Cancel,
             )
-            if reply == QtGui.QMessageBox.Yes:
+            if reply == QtWidgets.QMessageBox.Yes:
                 index = self.tabs.currentIndex()
                 table_key = self.tabs.tabText(index)
                 self.tabs.removeTab(index)
@@ -627,11 +627,11 @@ class Variables_dialog_editor(QtWidgets.QDialog):
     def set_tab_title(self):
         new_title = self.tab_title_edit.text()
         if new_title in self.tables:
-            QtGui.QMessageBox.warning(
+            QtWidgets.QMessageBox.warning(
                 self,
                 "Tab title already exists",
                 f"The new tab title must be different from existing tab titles.",
-                QtGui.QMessageBox.StandardButton.Ok,
+                QtWidgets.QMessageBox.StandardButton.Ok,
             )
             return
         index = self.tabs.currentIndex()
@@ -882,7 +882,7 @@ class Variables_table(QtWidgets.QTableWidget):
                         value = self.cellWidget(row, 7).text()
                         input_specs["step"] = float(value) if value.find(".") > -1 else int(value)
                     except:
-                        msg = QtGui.QMessageBox()
+                        msg = QtWidgets.QMessageBox()
                         msg.setText("Numbers for min, max, and step are required for spinboxes and sliders")
                         msg.exec()
                         return None

--- a/gui/custom_variables_dialog.py
+++ b/gui/custom_variables_dialog.py
@@ -8,12 +8,12 @@ from gui.utility import variable_constants, null_resize, cbox_set_item, cbox_upd
 # input widgets ---------------------------------------------------------------
 class Spin_var:
     def __init__(self, init_var_dict, label, spin_min, spin_max, step, varname):
-        center = QtCore.Qt.AlignCenter
-        Vcenter = QtCore.Qt.AlignVCenter
-        right = QtCore.Qt.AlignRight
+        center = QtCore.Qt.AlignmentFlag.AlignCenter
+        Vcenter = QtCore.Qt.AlignmentFlag.AlignVCenter
+        right = QtCore.Qt.AlignmentFlag.AlignRight
         button_width = 65
         spin_width = 85
-        self.label = QtGui.QLabel(label)
+        self.label = QtWidgets.QLabel(label)
         self.label.setAlignment(right | Vcenter)
         self.varname = varname
 
@@ -29,13 +29,13 @@ class Spin_var:
         self.spn.setMinimumWidth(spin_width)
         self.value_text_colour("gray")
 
-        self.get_btn = QtGui.QPushButton("Get")
+        self.get_btn = QtWidgets.QPushButton("Get")
         self.get_btn.setMinimumWidth(button_width)
         self.get_btn.setMaximumWidth(button_width)
         self.get_btn.setAutoDefault(False)
         self.get_btn.clicked.connect(self.get)
 
-        self.set_btn = QtGui.QPushButton("Set")
+        self.set_btn = QtWidgets.QPushButton("Set")
         self.set_btn.setMinimumWidth(button_width)
         self.set_btn.setMaximumWidth(button_width)
         self.set_btn.setAutoDefault(False)
@@ -99,15 +99,15 @@ class Spin_var:
 
 class Standard_var:
     def __init__(self, init_var_dict, label, varname, text_width=80):
-        center = QtCore.Qt.AlignCenter
-        Vcenter = QtCore.Qt.AlignVCenter
-        right = QtCore.Qt.AlignRight
+        center = QtCore.Qt.AlignmentFlag.AlignCenter
+        Vcenter = QtCore.Qt.AlignmentFlag.AlignVCenter
+        right = QtCore.Qt.AlignmentFlag.AlignRight
         button_width = 65
-        self.label = QtGui.QLabel(label)
+        self.label = QtWidgets.QLabel(label)
         self.label.setAlignment(right | Vcenter)
         self.varname = varname
 
-        self.line_edit = QtGui.QLineEdit()
+        self.line_edit = QtWidgets.QLineEdit()
         self.line_edit.setAlignment(center)
         self.line_edit.setMinimumWidth(text_width)
         self.line_edit.setMaximumWidth(text_width)
@@ -116,13 +116,13 @@ class Standard_var:
         self.line_edit.returnPressed.connect(self.set)
         self.value_text_colour("gray")
 
-        self.get_btn = QtGui.QPushButton("Get")
+        self.get_btn = QtWidgets.QPushButton("Get")
         self.get_btn.setMinimumWidth(button_width)
         self.get_btn.setMaximumWidth(button_width)
         self.get_btn.setAutoDefault(False)
         self.get_btn.clicked.connect(self.get)
 
-        self.set_btn = QtGui.QPushButton("Set")
+        self.set_btn = QtWidgets.QPushButton("Set")
         self.set_btn.setMinimumWidth(button_width)
         self.set_btn.setMaximumWidth(button_width)
         self.set_btn.setAutoDefault(False)
@@ -183,9 +183,9 @@ class Standard_var:
 class Checkbox_var:
     def __init__(self, init_var_dict, label, varname):
         self.varname = varname
-        self.label = QtGui.QLabel(label)
-        self.label.setAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
-        self.checkbox = QtGui.QCheckBox()
+        self.label = QtWidgets.QLabel(label)
+        self.label.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
+        self.checkbox = QtWidgets.QCheckBox()
         self.checkbox.setChecked(eval(init_var_dict[varname]))
         self.checkbox.clicked.connect(self.set)
 
@@ -208,7 +208,7 @@ class Checkbox_var:
         self.checkbox.setToolTip(hint)
 
 
-class DoubleSlider(QtGui.QSlider):  # https://stackoverflow.com/questions/4827885/qslider-stepping
+class DoubleSlider(QtWidgets.QSlider):  # https://stackoverflow.com/questions/4827885/qslider-stepping
     def __init__(self, *args, **kargs):
         super(DoubleSlider, self).__init__(*args, **kargs)
         self._min = 0
@@ -260,16 +260,16 @@ class Slider_var:
     def __init__(self, init_var_dict, label, slide_min, slide_max, step, varname):
         self.varname = varname
 
-        self.slider = DoubleSlider(QtCore.Qt.Horizontal)
-        self.slider.setTickPosition(QtGui.QSlider.TicksBelow)
+        self.slider = DoubleSlider(QtCore.Qt.Orientation.Horizontal)
+        self.slider.setTickPosition(QtWidgets.QSlider.TickPosition.TicksBelow)
         self.slider.setInterval(step)
         self.slider.setRange(slide_min, slide_max)
         self.slider.setValue(eval(init_var_dict[varname]))
 
         self.suffix = ""
-        self.label = QtGui.QLabel(label)
-        self.label.setAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
-        self.val_label = QtGui.QLabel(str(self.slider.value()))
+        self.label = QtWidgets.QLabel(label)
+        self.label.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
+        self.val_label = QtWidgets.QLabel(str(self.slider.value()))
 
         self.slider.sliderMoved.connect(self.update_val_lbl)
         self.slider.sliderReleased.connect(self.set)
@@ -302,9 +302,9 @@ class Slider_var:
 
 
 # GUI created from dictionary describing custom widgets and layout ------------
-class Custom_variables_dialog(QtGui.QDialog):
+class Custom_variables_dialog(QtWidgets.QDialog):
     def __init__(self, parent, gui_name, is_experiment=False):
-        super(QtGui.QDialog, self).__init__(parent)
+        super(QtWidgets.QDialog, self).__init__(parent)
         self.parent = parent
         self.gui_name = gui_name
         self.custom_gui = False
@@ -312,9 +312,9 @@ class Custom_variables_dialog(QtGui.QDialog):
         if self.generator_data:
             self.parent.print_to_log(f'\nLoading "{gui_name}" custom variable dialog')
             self.setWindowTitle("Set Variables")
-            self.layout = QtGui.QVBoxLayout(self)
+            self.layout = QtWidgets.QVBoxLayout(self)
             toolBar = QtGui.QToolBar()
-            toolBar.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
+            toolBar.setToolButtonStyle(QtCore.Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
             toolBar.setIconSize(QtCore.QSize(15, 15))
             self.layout.addWidget(toolBar)
             self.edit_action = QtGui.QAction(QtGui.QIcon("gui/icons/edit.svg"), "&edit", self)
@@ -322,7 +322,7 @@ class Custom_variables_dialog(QtGui.QDialog):
             if not is_experiment:
                 toolBar.addAction(self.edit_action)
                 self.edit_action.triggered.connect(self.edit)
-            self.scroll_area = QtGui.QScrollArea(parent=self)
+            self.scroll_area = QtWidgets.QScrollArea(parent=self)
             self.scroll_area.setWidgetResizable(True)
             self.variables_grid = Custom_variables_grid(self, parent.board, self.generator_data)
             self.scroll_area.setWidget(self.variables_grid)
@@ -373,23 +373,23 @@ class Custom_variables_dialog(QtGui.QDialog):
         return False
 
 
-class Custom_variables_grid(QtGui.QWidget):
+class Custom_variables_grid(QtWidgets.QWidget):
     def __init__(self, parent, board, generator_data):
-        super(QtGui.QWidget, self).__init__(parent)
-        grid_layout = QtGui.QGridLayout()
+        super(QtWidgets.QWidget, self).__init__(parent)
+        grid_layout = QtWidgets.QGridLayout()
         variables = board.sm_info["variables"]
         init_vars = dict(sorted(variables.items()))
-        variable_tabs = QtGui.QTabWidget()
+        variable_tabs = QtWidgets.QTabWidget()
         used_vars = []
         self.widget_dict = {}
         for tab in generator_data["ordered_tabs"]:  # create widgets
-            widget = QtGui.QWidget()
-            layout = QtGui.QGridLayout()
+            widget = QtWidgets.QWidget()
+            layout = QtWidgets.QGridLayout()
             tab_data = generator_data[tab]
             used_vars.extend(tab_data["ordered_inputs"])
             for row, var in enumerate(tab_data["ordered_inputs"]):
                 if var.find("sep") > -1:
-                    layout.addWidget(QtGui.QLabel("<hr>"), row, 0, 1, 4)
+                    layout.addWidget(QtWidgets.QLabel("<hr>"), row, 0, 1, 4)
                 else:
                     try:
                         control = tab_data[var]
@@ -416,12 +416,13 @@ class Custom_variables_grid(QtGui.QWidget):
                         parent.parent.print_to_log(
                             f'- Loading error: could not find "{var}" variable in the task file. The variable name has been changed or no longer exists.'
                         )
-            layout.setAlignment(QtCore.Qt.AlignTop)
+            
+            layout.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop)
             widget.setLayout(layout)
             variable_tabs.addTab(widget, tab)
 
-        leftover_widget = QtGui.QWidget()
-        leftover_layout = QtGui.QGridLayout()
+        leftover_widget = QtWidgets.QWidget()
+        leftover_layout = QtWidgets.QGridLayout()
         leftover_vars = sorted(list(set(variables) - set(used_vars)), key=str.lower)
         leftover_vars = [
             v_name for v_name in leftover_vars if not v_name[-3:] == "___" and v_name != "custom_variables_dialog"
@@ -431,19 +432,19 @@ class Custom_variables_grid(QtGui.QWidget):
                 self.widget_dict[var] = Standard_var(init_vars, var, var)
                 self.widget_dict[var].setBoard(board)
                 self.widget_dict[var].add_to_grid(leftover_layout, row)
-            leftover_layout.setAlignment(QtCore.Qt.AlignTop)
+            leftover_layout.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop)
             leftover_widget.setLayout(leftover_layout)
             variable_tabs.addTab(leftover_widget, "...")
 
-        grid_layout.addWidget(variable_tabs, 0, 0, QtCore.Qt.AlignLeft)
-        grid_layout.setAlignment(QtCore.Qt.AlignTop)
+        grid_layout.addWidget(variable_tabs, 0, 0, QtCore.Qt.AlignmentFlag.AlignLeft)
+        grid_layout.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop)
         self.setLayout(grid_layout)
 
 
 # GUI editor dialog. ---------------------------------------------------------
-class Variables_dialog_editor(QtGui.QDialog):
+class Variables_dialog_editor(QtWidgets.QDialog):
     def __init__(self, parent, gui_name, data_to_load=None):
-        super(QtGui.QDialog, self).__init__(parent)
+        super(QtWidgets.QDialog, self).__init__(parent)
         self.gui_name = gui_name
         self.available_vars = []
         self.get_vars(parent.task)
@@ -451,40 +452,40 @@ class Variables_dialog_editor(QtGui.QDialog):
 
         self.setWindowTitle("Custom Variable Dialog Editor")
         # main widgets
-        self.tabs = QtGui.QTabWidget()
-        self.add_tab_btn = QtGui.QPushButton("add tab")
+        self.tabs = QtWidgets.QTabWidget()
+        self.add_tab_btn = QtWidgets.QPushButton("add tab")
         self.add_tab_btn.setIcon(QtGui.QIcon("gui/icons/add.svg"))
         self.add_tab_btn.clicked.connect(self.add_tab)
-        self.add_tab_btn.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.add_tab_btn.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
 
-        self.del_tab_btn = QtGui.QPushButton("remove tab")
+        self.del_tab_btn = QtWidgets.QPushButton("remove tab")
         self.del_tab_btn.setIcon(QtGui.QIcon("gui/icons/remove.svg"))
         self.del_tab_btn.clicked.connect(self.remove_tab)
-        self.del_tab_btn.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.del_tab_btn.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
 
-        self.tab_title_lbl = QtGui.QLabel("Tab title:")
-        self.tab_title_edit = QtGui.QLineEdit()
+        self.tab_title_lbl = QtWidgets.QLabel("Tab title:")
+        self.tab_title_edit = QtWidgets.QLineEdit()
         self.tab_title_edit.setMinimumWidth(200)
         self.tab_title_edit.returnPressed.connect(self.set_tab_title)
-        self.tab_title_btn = QtGui.QPushButton("set title")
-        self.tab_title_btn.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.tab_title_btn = QtWidgets.QPushButton("set title")
+        self.tab_title_btn.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
         self.tab_title_btn.clicked.connect(self.set_tab_title)
 
-        self.tab_shift_left_btn = QtGui.QPushButton("shift tab")
+        self.tab_shift_left_btn = QtWidgets.QPushButton("shift tab")
         self.tab_shift_left_btn.setIcon(QtGui.QIcon("gui/icons/left.svg"))
-        self.tab_shift_left_btn.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.tab_shift_left_btn.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
         self.tab_shift_left_btn.clicked.connect(self.shift_tab_left)
 
-        self.tab_shift_right_btn = QtGui.QPushButton("shift tab")
+        self.tab_shift_right_btn = QtWidgets.QPushButton("shift tab")
         self.tab_shift_right_btn.setIcon(QtGui.QIcon("gui/icons/right.svg"))
-        self.tab_shift_right_btn.setLayoutDirection(QtCore.Qt.RightToLeft)
-        self.tab_shift_right_btn.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.tab_shift_right_btn.setLayoutDirection(QtCore.Qt.LayoutDirection.RightToLeft)
+        self.tab_shift_right_btn.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
         self.tab_shift_right_btn.clicked.connect(self.shift_tab_right)
 
-        self.save_gui_btn = QtGui.QPushButton("Save GUI")
+        self.save_gui_btn = QtWidgets.QPushButton("Save GUI")
         self.save_gui_btn.setIcon(QtGui.QIcon("gui/icons/save.svg"))
         self.save_gui_btn.clicked.connect(self.save_gui_data)
-        self.save_gui_btn.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.save_gui_btn.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
         if data_to_load:
             self.load_gui_data(data_to_load)
         else:
@@ -493,8 +494,8 @@ class Variables_dialog_editor(QtGui.QDialog):
         self.refresh_variable_options()
 
         # layout
-        tab_box = QtGui.QGroupBox("")
-        tab_box_layout = QtGui.QGridLayout(self)
+        tab_box = QtWidgets.QGroupBox("")
+        tab_box_layout = QtWidgets.QGridLayout(self)
         tab_box_layout.addWidget(self.add_tab_btn, 0, 0)
         tab_box_layout.addWidget(self.del_tab_btn, 0, 1)
         tab_box_layout.addWidget(self.tab_title_lbl, 0, 2)
@@ -504,7 +505,7 @@ class Variables_dialog_editor(QtGui.QDialog):
         tab_box_layout.addWidget(self.tab_shift_right_btn, 0, 6)
         tab_box.setLayout(tab_box_layout)
 
-        self.layout = QtGui.QGridLayout(self)
+        self.layout = QtWidgets.QGridLayout(self)
         self.layout.addWidget(tab_box, 0, 0)
         self.layout.addWidget(self.save_gui_btn, 0, 7)
         self.layout.addWidget(self.tabs, 1, 0, 1, 8)
@@ -630,7 +631,7 @@ class Variables_dialog_editor(QtGui.QDialog):
                 self,
                 "Tab title already exists",
                 f"The new tab title must be different from existing tab titles.",
-                QtGui.QMessageBox.Ok,
+                QtGui.QMessageBox.StandardButton.Ok,
             )
             return
         index = self.tabs.currentIndex()
@@ -646,28 +647,28 @@ class Variable_row:
     def __init__(self, parent, var_name=False, row_data=False):
         self.parent = parent
         # buttons
-        self.up_button = QtGui.QPushButton("")
+        self.up_button = QtWidgets.QPushButton("")
         self.up_button.setIcon(QtGui.QIcon("gui/icons/up.svg"))
-        self.down_button = QtGui.QPushButton("")
+        self.down_button = QtWidgets.QPushButton("")
         self.down_button.setIcon(QtGui.QIcon("gui/icons/down.svg"))
-        self.remove_button = QtGui.QPushButton("remove")
+        self.remove_button = QtWidgets.QPushButton("remove")
         self.remove_button.setIcon(QtGui.QIcon("gui/icons/remove.svg"))
         # line edits
-        self.display_name = QtGui.QLineEdit()
-        self.spin_min = QtGui.QLineEdit()
-        self.spin_min.setAlignment(QtCore.Qt.AlignCenter)
-        self.spin_max = QtGui.QLineEdit()
-        self.spin_max.setAlignment(QtCore.Qt.AlignCenter)
-        self.spin_step = QtGui.QLineEdit()
-        self.spin_step.setAlignment(QtCore.Qt.AlignCenter)
-        self.suffix = QtGui.QLineEdit()
-        self.suffix.setAlignment(QtCore.Qt.AlignCenter)
-        self.hint = QtGui.QLineEdit()
+        self.display_name = QtWidgets.QLineEdit()
+        self.spin_min = QtWidgets.QLineEdit()
+        self.spin_min.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        self.spin_max = QtWidgets.QLineEdit()
+        self.spin_max.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        self.spin_step = QtWidgets.QLineEdit()
+        self.spin_step.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        self.suffix = QtWidgets.QLineEdit()
+        self.suffix.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        self.hint = QtWidgets.QLineEdit()
         # combo boxes
-        self.variable_cbox = QtGui.QComboBox()
+        self.variable_cbox = QtWidgets.QComboBox()
         self.variable_cbox.activated.connect(lambda: self.parent.clear_label(self.display_name.text()))
         self.variable_cbox.addItems(["     select variable     "] + self.parent.parent.available_vars)
-        self.input_type_combo = QtGui.QComboBox()
+        self.input_type_combo = QtWidgets.QComboBox()
         self.input_type_combo.activated.connect(self.parent.update_available)
         self.input_type_combo.addItems(["line edit", "checkbox", "spinbox", "slider"])
 
@@ -722,9 +723,9 @@ class Variable_row:
             self.parent.setCellWidget(row_index, column, widget)
 
 
-class Variables_table(QtGui.QTableWidget):
+class Variables_table(QtWidgets.QTableWidget):
     def __init__(self, parent=None, data=None):
-        super(QtGui.QTableWidget, self).__init__(1, 11, parent=parent)
+        super(QtWidgets.QTableWidget, self).__init__(1, 11, parent=parent)
         self.parent = parent
         self.setHorizontalHeaderLabels(
             ["", "", "Variable", "Label", "Input type", "Min", "Max", "Step", "Suffix", "Hint", ""]
@@ -747,7 +748,7 @@ class Variables_table(QtGui.QTableWidget):
             for element in data["ordered_inputs"]:
                 self.add_row(element, data[element])
             # after done loading control rows, insert another row with an "add" button
-            add_button = QtGui.QPushButton("   add   ")
+            add_button = QtWidgets.QPushButton("   add   ")
             add_button.setIcon(QtGui.QIcon("gui/icons/add.svg"))
             add_button.clicked.connect(self.add_row)
             self.setCellWidget(self.n_variables, 10, add_button)
@@ -765,7 +766,7 @@ class Variables_table(QtGui.QTableWidget):
         # insert another row with an "add" button
         self.insertRow(self.n_variables + 1)
         if not varname:
-            add_button = QtGui.QPushButton("   add   ")
+            add_button = QtWidgets.QPushButton("   add   ")
             add_button.setIcon(QtGui.QIcon("gui/icons/add.svg"))
             add_button.clicked.connect(self.add_row)
             self.setCellWidget(self.n_variables + 1, 10, add_button)
@@ -894,17 +895,17 @@ class Variables_table(QtGui.QTableWidget):
         return tab_dictionary
 
 
-class Custom_variables_not_found_dialog(QtGui.QDialog):
+class Custom_variables_not_found_dialog(QtWidgets.QDialog):
     def __init__(self, missing_file, parent):
-        super(QtGui.QDialog, self).__init__(parent)
+        super(QtWidgets.QDialog, self).__init__(parent)
         self.setWindowTitle("Custom variable dialog not found")
 
-        message = QtGui.QLabel(f'The custom variable dialog <b>"{missing_file}"</b> was not found.<br><br>')
-        continue_button = QtGui.QPushButton("Continue with standard variable dialog")
-        generate_button = QtGui.QPushButton("Create new custom variable dialog")
+        message = QtWidgets.QLabel(f'The custom variable dialog <b>"{missing_file}"</b> was not found.<br><br>')
+        continue_button = QtWidgets.QPushButton("Continue with standard variable dialog")
+        generate_button = QtWidgets.QPushButton("Create new custom variable dialog")
         continue_button.setDefault(True)
         continue_button.setFocus()
-        self.layout = QtGui.QGridLayout(self)
+        self.layout = QtWidgets.QGridLayout(self)
         self.layout.addWidget(message, 0, 0, 1, 2)
         self.layout.addWidget(continue_button, 1, 0)
         self.layout.addWidget(generate_button, 1, 1)

--- a/gui/dialogs.py
+++ b/gui/dialogs.py
@@ -46,16 +46,16 @@ class Board_config_dialog(QtWidgets.QDialog):
     def load_framework(self):
         self.accept()
         if self.flashdrive_enabled:
-            reply = QtGui.QMessageBox.question(self, 'Disable flashdrive', 
-                flashdrive_message, QtGui.QMessageBox.StandardButton.Yes | QtGui.QMessageBox.StandardButton.No)
-            if reply == QtGui.QMessageBox.StandardButton.Yes:
+            reply = QtWidgets.QMessageBox.question(self, 'Disable flashdrive', 
+                flashdrive_message, QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No)
+            if reply == QtWidgets.QMessageBox.StandardButton.Yes:
                 self.board.disable_mass_storage()
                 self.disconnect = True
                 return
         self.board.load_framework()
 
     def load_hardware_definition(self):
-        hwd_path = QtGui.QFileDialog.getOpenFileName(self, 'Select hardware definition:',
+        hwd_path = QtWidgets.QFileDialog.getOpenFileName(self, 'Select hardware definition:',
                     os.path.join(dirs['config'], 'hardware_definition.py'), filter='*.py')[0]
         self.accept()
         self.board.load_hardware_definition(hwd_path)
@@ -183,8 +183,8 @@ class Summary_variables_dialog(QtWidgets.QDialog):
         self.label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
 
         self.table = QtWidgets.QTableWidget(len(subjects), len(v_names),  parent=self)
-        self.table.setSizeAdjustPolicy(QtGui.QAbstractScrollArea.AdjustToContents)
-        self.table.setEditTriggers(QtGui.QAbstractItemView.NoEditTriggers)
+        self.table.setSizeAdjustPolicy(QtWidgets.QAbstractScrollArea.AdjustToContents)
+        self.table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
         self.table.setHorizontalHeaderLabels(v_names)
         self.table.setVerticalHeaderLabels(subjects)
 
@@ -211,19 +211,19 @@ class Summary_variables_dialog(QtWidgets.QDialog):
 # Invalid experiment dialog. ---------------------------------------------------------
 
 def invalid_run_experiment_dialog(parent, message):
-    QtGui.QMessageBox.warning(parent, 'Invalid experiment', 
-        message + '\n\nUnable to run experiment.', QtGui.QMessageBox.StandardButton.Ok)
+    QtWidgets.QMessageBox.warning(parent, 'Invalid experiment', 
+        message + '\n\nUnable to run experiment.', QtWidgets.QMessageBox.StandardButton.Ok)
 
 def invalid_save_experiment_dialog(parent, message):
-    QtGui.QMessageBox.warning(parent, 'Invalid experiment', 
-        message + '\n\nUnable to save experiment.', QtGui.QMessageBox.StandardButton.Ok)
+    QtWidgets.QMessageBox.warning(parent, 'Invalid experiment', 
+        message + '\n\nUnable to save experiment.', QtWidgets.QMessageBox.StandardButton.Ok)
 
 # Unrun subjects warning     ---------------------------------------------------------
 
 def unrun_subjects_dialog(parent,message):
-    reply = QtGui.QMessageBox.warning(parent, 'Unrun Subjects', 
-        'The following Subjects will not be run:\n\n{}'.format(message), (QtGui.QMessageBox.StandardButton.Ok | QtGui.QMessageBox.StandardButton.Cancel))
-    if reply == QtGui.QMessageBox.StandardButton.Ok:
+    reply = QtWidgets.QMessageBox.warning(parent, 'Unrun Subjects', 
+        'The following Subjects will not be run:\n\n{}'.format(message), (QtWidgets.QMessageBox.StandardButton.Ok | QtWidgets.QMessageBox.StandardButton.Cancel))
+    if reply == QtWidgets.QMessageBox.StandardButton.Ok:
         return True
     else:
         return False
@@ -288,7 +288,7 @@ class Path_setter():
         self.dialog.setters.append(self)
 
     def select_path(self):
-        new_path = QtGui.QFileDialog.getExistingDirectory(
+        new_path = QtWidgets.QFileDialog.getExistingDirectory(
             self.dialog, 'Select {} folder'.format(self.name), self.path)
         if new_path:
             new_path = os.path.normpath(new_path)

--- a/gui/dialogs.py
+++ b/gui/dialogs.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-from pyqtgraph.Qt import QtGui, QtCore
+from pyqtgraph.Qt import QtGui, QtCore, QtWidgets
 
 from config.paths import dirs, update_paths
 from gui.utility import variable_constants
@@ -13,17 +13,17 @@ flashdrive_message = (
     'USB flash drive before loading the framework, as this helps prevent the '
     'filesystem getting corrupted. Do you want to disable the flashdrive?')
 
-class Board_config_dialog(QtGui.QDialog):
+class Board_config_dialog(QtWidgets.QDialog):
     def __init__(self, parent=None):
-        super(QtGui.QDialog, self).__init__(parent)
+        super(QtWidgets.QDialog, self).__init__(parent)
         self.setWindowTitle('Configure pyboard')
         # Create widgets.
-        self.load_fw_button = QtGui.QPushButton('Load framework')
-        self.load_hw_button = QtGui.QPushButton('Load hardware definition')
-        self.DFU_button = QtGui.QPushButton('Device Firmware Update (DFU) mode')
-        self.flashdrive_button = QtGui.QPushButton()
+        self.load_fw_button = QtWidgets.QPushButton('Load framework')
+        self.load_hw_button = QtWidgets.QPushButton('Load hardware definition')
+        self.DFU_button = QtWidgets.QPushButton('Device Firmware Update (DFU) mode')
+        self.flashdrive_button = QtWidgets.QPushButton()
         # Layout.
-        self.vertical_layout = QtGui.QVBoxLayout()
+        self.vertical_layout = QtWidgets.QVBoxLayout()
         self.setLayout(self.vertical_layout)
         self.vertical_layout.addWidget(self.load_fw_button)
         self.vertical_layout.addWidget(self.load_hw_button)
@@ -35,20 +35,20 @@ class Board_config_dialog(QtGui.QDialog):
         self.DFU_button.clicked.connect(self.DFU_mode)
         self.flashdrive_button.clicked.connect(self.flashdrive)
 
-    def exec_(self, board):
+    def exec(self, board):
         self.board = board
         self.flashdrive_enabled = 'MSC' in self.board.status['usb_mode']
         self.flashdrive_button.setText('{} USB flash drive'
             .format('Disable' if self.flashdrive_enabled else 'Enable'))
         self.disconnect = False # Indicates whether board was disconnected by dialog.
-        return QtGui.QDialog.exec_(self)
+        return QtWidgets.QDialog.exec(self)
 
     def load_framework(self):
         self.accept()
         if self.flashdrive_enabled:
             reply = QtGui.QMessageBox.question(self, 'Disable flashdrive', 
-                flashdrive_message, QtGui.QMessageBox.Yes | QtGui.QMessageBox.No)
-            if reply == QtGui.QMessageBox.Yes:
+                flashdrive_message, QtGui.QMessageBox.StandardButton.Yes | QtGui.QMessageBox.StandardButton.No)
+            if reply == QtGui.QMessageBox.StandardButton.Yes:
                 self.board.disable_mass_storage()
                 self.disconnect = True
                 return
@@ -75,43 +75,43 @@ class Board_config_dialog(QtGui.QDialog):
 
 # Variables_dialog ---------------------------------------------------------------------
 
-class Variables_dialog(QtGui.QDialog):
+class Variables_dialog(QtWidgets.QDialog):
     # Dialog for setting and getting task variables.
     def __init__(self, parent, board):
-        super(QtGui.QDialog, self).__init__(parent)
+        super(QtWidgets.QDialog, self).__init__(parent)
         self.setWindowTitle('Set variables')
-        self.scroll_area = QtGui.QScrollArea(parent=self)
+        self.scroll_area = QtWidgets.QScrollArea(parent=self)
         self.scroll_area.setWidgetResizable(True)
         self.variables_grid = Variables_grid(self.scroll_area, board)
         self.scroll_area.setWidget(self.variables_grid)
-        self.layout = QtGui.QVBoxLayout(self)
+        self.layout = QtWidgets.QVBoxLayout(self)
         self.layout.addWidget(self.scroll_area)
         self.setLayout(self.layout)
 
         self.close_shortcut = QtGui.QShortcut(QtGui.QKeySequence('Ctrl+W'), self)
         self.close_shortcut.activated.connect(self.close)
 
-class Variables_grid(QtGui.QWidget):
+class Variables_grid(QtWidgets.QWidget):
     # Grid of variables to set/get, displayed within scroll area of dialog.
     def __init__(self, parent, board):
-        super(QtGui.QWidget, self).__init__(parent)
+        super(QtWidgets.QWidget, self).__init__(parent)
         variables = board.sm_info['variables']
-        self.grid_layout = QtGui.QGridLayout()
+        self.grid_layout = QtWidgets.QGridLayout()
         for i, (v_name, v_value_str) in enumerate(sorted(variables.items())):
             if not v_name[-3:] == '___':
                 Variable_setter(v_name, v_value_str, self.grid_layout, i, self, board)
         self.setLayout(self.grid_layout)
 
-class Variable_setter(QtGui.QWidget):
+class Variable_setter(QtWidgets.QWidget):
     # For setting and getting a single variable.
     def __init__(self, v_name, v_value_str, grid_layout, i, parent, board): # Should split into seperate init and provide info.
-        super(QtGui.QWidget, self).__init__(parent)
+        super(QtWidgets.QWidget, self).__init__(parent)
         self.board = board
         self.v_name = v_name
-        self.label = QtGui.QLabel(v_name)
-        self.get_button = QtGui.QPushButton('Get value')
-        self.set_button = QtGui.QPushButton('Set value')
-        self.value_str = QtGui.QLineEdit(v_value_str)
+        self.label = QtWidgets.QLabel(v_name)
+        self.get_button = QtWidgets.QPushButton('Get value')
+        self.set_button = QtWidgets.QPushButton('Set value')
+        self.value_str = QtWidgets.QLineEdit(v_value_str)
         if v_value_str[0] == '<': # Variable is a complex object that cannot be modifed.
             self.value_str.setText('<complex object>')
             self.set_button.setEnabled(False)
@@ -168,27 +168,27 @@ class Variable_setter(QtGui.QWidget):
 
 # Summary variables dialog -----------------------------------------------------------
 
-class Summary_variables_dialog(QtGui.QDialog):
+class Summary_variables_dialog(QtWidgets.QDialog):
     '''Dialog for displaying summary variables from an experiment as a table.
     The table is copied to the clipboard as a string that can be pasted into a
     spreadsheet.'''
     def __init__(self, parent, sv_dict):
-        super(QtGui.QDialog, self).__init__(parent)
+        super(QtWidgets.QDialog, self).__init__(parent)
         self.setWindowTitle('Summary variables')
 
         subjects = list(sv_dict.keys())
         v_names  = sorted(sv_dict[subjects[0]].keys())
 
-        self.label = QtGui.QLabel('Summary variables copied to clipboard.')
-        self.label.setAlignment(QtCore.Qt.AlignCenter)
+        self.label = QtWidgets.QLabel('Summary variables copied to clipboard.')
+        self.label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
 
-        self.table = QtGui.QTableWidget(len(subjects), len(v_names),  parent=self)
+        self.table = QtWidgets.QTableWidget(len(subjects), len(v_names),  parent=self)
         self.table.setSizeAdjustPolicy(QtGui.QAbstractScrollArea.AdjustToContents)
         self.table.setEditTriggers(QtGui.QAbstractItemView.NoEditTriggers)
         self.table.setHorizontalHeaderLabels(v_names)
         self.table.setVerticalHeaderLabels(subjects)
 
-        self.Vlayout = QtGui.QVBoxLayout(self)
+        self.Vlayout = QtWidgets.QVBoxLayout(self)
         self.Vlayout.addWidget(self.label)
         self.Vlayout.addWidget(self.table)
 
@@ -199,46 +199,46 @@ class Summary_variables_dialog(QtGui.QDialog):
             for v, v_name in enumerate(v_names):
                 v_value_str = repr(sv_dict[subject][v_name])
                 clip_string += '\t' + v_value_str
-                item = QtGui.QTableWidgetItem()
+                item = QtWidgets.QTableWidgetItem()
                 item.setText(v_value_str)
                 self.table.setItem(s, v, item)
 
         self.table.resizeColumnsToContents()
 
-        clipboard = QtGui.QApplication.clipboard()
+        clipboard = QtWidgets.QApplication.clipboard()
         clipboard.setText(clip_string)
 
 # Invalid experiment dialog. ---------------------------------------------------------
 
 def invalid_run_experiment_dialog(parent, message):
     QtGui.QMessageBox.warning(parent, 'Invalid experiment', 
-        message + '\n\nUnable to run experiment.', QtGui.QMessageBox.Ok)
+        message + '\n\nUnable to run experiment.', QtGui.QMessageBox.StandardButton.Ok)
 
 def invalid_save_experiment_dialog(parent, message):
     QtGui.QMessageBox.warning(parent, 'Invalid experiment', 
-        message + '\n\nUnable to save experiment.', QtGui.QMessageBox.Ok)
+        message + '\n\nUnable to save experiment.', QtGui.QMessageBox.StandardButton.Ok)
 
 # Unrun subjects warning     ---------------------------------------------------------
 
 def unrun_subjects_dialog(parent,message):
     reply = QtGui.QMessageBox.warning(parent, 'Unrun Subjects', 
-        'The following Subjects will not be run:\n\n{}'.format(message), (QtGui.QMessageBox.Ok | QtGui.QMessageBox.Cancel))
-    if reply == QtGui.QMessageBox.Ok:
+        'The following Subjects will not be run:\n\n{}'.format(message), (QtGui.QMessageBox.StandardButton.Ok | QtGui.QMessageBox.StandardButton.Cancel))
+    if reply == QtGui.QMessageBox.StandardButton.Ok:
         return True
     else:
         return False
         
 # Keyboard shortcuts dialog. ---------------------------------------------------------
 
-class Keyboard_shortcuts_dialog(QtGui.QDialog):
+class Keyboard_shortcuts_dialog(QtWidgets.QDialog):
     '''Dialog for displaying information about keyboard shortcuts.'''
     def __init__(self, parent):
-        super(QtGui.QDialog, self).__init__(parent)
+        super(QtWidgets.QDialog, self).__init__(parent)
         self.setWindowTitle('Shortcuts')
 
-        self.Vlayout = QtGui.QVBoxLayout(self)
+        self.Vlayout = QtWidgets.QVBoxLayout(self)
 
-        label = QtGui.QLabel('<center><b>Keyboard Shortcuts</b></center<br></br>')
+        label = QtWidgets.QLabel('<center><b>Keyboard Shortcuts</b></center<br></br>')
         label.setFont(QtGui.QFont('Helvetica', 12))
         self.Vlayout.addWidget(label)
 
@@ -256,7 +256,7 @@ class Keyboard_shortcuts_dialog(QtGui.QDialog):
             '<b style="color:#0220e0;">Ctrl + s</b> : Save experiment ']
 
         for ls in label_strings:
-            label = QtGui.QLabel(ls)
+            label = QtWidgets.QLabel(ls)
             label.setFont(QtGui.QFont('Helvetica', 10))
             self.Vlayout.addWidget(label)
 
@@ -272,14 +272,14 @@ class Path_setter():
         self.edited = edited
         self.dialog = dialog
         # Instantiate widgets
-        self.name_label = QtGui.QLabel(name +' folder:')
-        self.path_text = QtGui.QLineEdit(self.path)
+        self.name_label = QtWidgets.QLabel(name +' folder:')
+        self.path_text = QtWidgets.QLineEdit(self.path)
         self.path_text.setReadOnly(True)
         self.path_text.setFixedWidth(400)
-        self.change_button = QtGui.QPushButton('Change')
+        self.change_button = QtWidgets.QPushButton('Change')
         self.change_button.clicked.connect(self.select_path)
         # Layout
-        self.hlayout = QtGui.QHBoxLayout()
+        self.hlayout = QtWidgets.QHBoxLayout()
         self.hlayout.addWidget(self.name_label)
         self.hlayout.addWidget(self.path_text)
         self.hlayout.addWidget(self.change_button)
@@ -297,12 +297,12 @@ class Path_setter():
                 self.edited = True
                 self.path_text.setText(new_path)
 
-class Paths_dialog(QtGui.QDialog):
+class Paths_dialog(QtWidgets.QDialog):
     def __init__(self, parent):
-        super(QtGui.QDialog, self).__init__(parent)
+        super(QtWidgets.QDialog, self).__init__(parent)
         self.setWindowTitle('Paths')
 
-        self.Vlayout = QtGui.QVBoxLayout(self)
+        self.Vlayout = QtWidgets.QVBoxLayout(self)
         self.setters = []
 
         # Instantiate setters

--- a/gui/plotting.py
+++ b/gui/plotting.py
@@ -1,9 +1,8 @@
 import time
-import numpy as np
 from datetime import timedelta
+import numpy as np
 import pyqtgraph as pg
-from pyqtgraph.Qt import QtGui
-from PyQt5.QtCore import Qt
+from pyqtgraph.Qt import QtGui,QtWidgets,QtCore
 
 from config.gui_settings import event_history_len, state_history_len, analog_history_dur
 from gui.utility import detachableTabWidget
@@ -12,11 +11,11 @@ from gui.utility import detachableTabWidget
 # Task_plot 
 # ----------------------------------------------------------------------------------------
 
-class Task_plot(QtGui.QWidget):
+class Task_plot(QtWidgets.QWidget):
     ''' Widget for plotting the states, events and analog inputs output by a state machine.'''
 
     def __init__(self, parent=None):
-        super(QtGui.QWidget, self).__init__(parent)
+        super(QtWidgets.QWidget, self).__init__(parent)
 
         # Create widgets
 
@@ -26,7 +25,7 @@ class Task_plot(QtGui.QWidget):
         self.run_clock   = Run_clock(self.states_plot.axis)
 
         # Setup plots
-        self.pause_button = QtGui.QPushButton()
+        self.pause_button = QtWidgets.QPushButton()
         self.pause_button.setEnabled(False)
         self.pause_button.setCheckable(True)
         self.events_plot.axis.setXLink(self.states_plot.axis)
@@ -35,11 +34,11 @@ class Task_plot(QtGui.QWidget):
 
         # create layout
 
-        self.vertical_layout = QtGui.QGridLayout()
+        self.vertical_layout = QtWidgets.QGridLayout()
         self.vertical_layout.addWidget(self.states_plot.axis,0,0,1,3)
         self.vertical_layout.addWidget(self.events_plot.axis,1,0,1,3)
         self.vertical_layout.addWidget(self.analog_plot.axis,2,0,1,3)
-        self.vertical_layout.addWidget(self.pause_button,3,0,1,3,Qt.AlignCenter)
+        self.vertical_layout.addWidget(self.pause_button,3,0,1,3,QtCore.Qt.AlignmentFlag.AlignCenter)
         self.setLayout(self.vertical_layout)
 
         self.pause_button.clicked.connect(self.update_pause_btn_text)
@@ -254,12 +253,12 @@ class Run_clock():
 
     def __init__(self, axis):
         self.clock_text = pg.TextItem(text='')
-        self.clock_text.setFont(QtGui.QFont('arial',11, QtGui.QFont.Bold))
+        self.clock_text.setFont(QtGui.QFont('arial',11, QtGui.QFont.Weight.Bold))
         axis.getViewBox().addItem(self.clock_text, ignoreBounds=True)
         self.clock_text.setParentItem(axis.getViewBox())
         self.clock_text.setPos(10,-5)
         self.recording_text = pg.TextItem(text='', color=(255,0,0))
-        self.recording_text.setFont(QtGui.QFont('arial',12,QtGui.QFont.Bold))
+        self.recording_text.setFont(QtGui.QFont('arial',12,QtGui.QFont.Weight.Bold))
         axis.getViewBox().addItem(self.recording_text, ignoreBounds=True)
         self.recording_text.setParentItem(axis.getViewBox())
         self.recording_text.setPos(80,-5)
@@ -278,12 +277,12 @@ class Run_clock():
 # Experiment plotter
 # --------------------------------------------------------------------------------
 
-class Experiment_plot(QtGui.QMainWindow):
+class Experiment_plot(QtWidgets.QMainWindow):
     '''Window for plotting data during experiment run where each subjects plots
     are displayed in a seperate tab.'''
 
     def __init__(self, parent=None):
-        super(QtGui.QWidget, self).__init__(parent)
+        super(QtWidgets.QWidget, self).__init__(parent)
         self.setWindowTitle('Experiment plot')
         self.setGeometry(720, 30, 700, 800) # Left, top, width, height.       
         self.subject_tabs = detachableTabWidget(self)
@@ -316,6 +315,7 @@ class Experiment_plot(QtGui.QMainWindow):
             subject_plot = self.subject_plots.pop() 
             subject_plot.setParent(None)
             subject_plot.deleteLater()
+        self.subject_tabs.closeDetachedTabs()
         self.close()
         
     def update(self):

--- a/gui/run_experiment_tab.py
+++ b/gui/run_experiment_tab.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from collections import OrderedDict
 
 from concurrent.futures import ThreadPoolExecutor
-from pyqtgraph.Qt import QtGui, QtCore
+from pyqtgraph.Qt import QtGui, QtCore, QtWidgets
 from serial import SerialException
 
 from config.gui_settings import  update_interval, log_font_size
@@ -18,42 +18,42 @@ from gui.dialogs import Variables_dialog, Summary_variables_dialog
 from gui.utility import variable_constants, TaskInfo
 from gui.custom_variables_dialog import Custom_variables_dialog
 
-class Run_experiment_tab(QtGui.QWidget):
+class Run_experiment_tab(QtWidgets.QWidget):
     '''The run experiment tab is responsible for setting up, running and stopping
     an experiment that has been defined using the configure experiments tab.'''
 
     def __init__(self, parent=None):
-        super(QtGui.QWidget, self).__init__(parent)
+        super(QtWidgets.QWidget, self).__init__(parent)
 
         self.GUI_main = self.parent()
         self.experiment_plot = Experiment_plot(self)
 
-        self.name_label = QtGui.QLabel('Experiment name:')
-        self.name_text  = QtGui.QLineEdit()
+        self.name_label = QtWidgets.QLabel('Experiment name:')
+        self.name_text  = QtWidgets.QLineEdit()
         self.name_text.setReadOnly(True)
-        self.plots_button =  QtGui.QPushButton('Show plots')
+        self.plots_button =  QtWidgets.QPushButton('Show plots')
         self.plots_button.setIcon(QtGui.QIcon("gui/icons/bar-graph.svg"))
         self.plots_button.clicked.connect(self.experiment_plot.show)
-        self.logs_button = QtGui.QPushButton('Hide logs')
+        self.logs_button = QtWidgets.QPushButton('Hide logs')
         self.logs_button.clicked.connect(self.show_hide_logs)
-        self.startstopclose_all_button = QtGui.QPushButton()
+        self.startstopclose_all_button = QtWidgets.QPushButton()
         self.startstopclose_all_button.clicked.connect(self.startstopclose_all)
 
-        self.Hlayout = QtGui.QHBoxLayout()
+        self.Hlayout = QtWidgets.QHBoxLayout()
         self.Hlayout.addWidget(self.name_label)
         self.Hlayout.addWidget(self.name_text)
         self.Hlayout.addWidget(self.logs_button)
         self.Hlayout.addWidget(self.plots_button)
         self.Hlayout.addWidget(self.startstopclose_all_button)
 
-        self.scroll_area = QtGui.QScrollArea(parent=self)
+        self.scroll_area = QtWidgets.QScrollArea(parent=self)
         self.scroll_area.horizontalScrollBar().setEnabled(False)
-        self.scroll_inner = QtGui.QFrame(self)
-        self.boxes_layout = QtGui.QVBoxLayout(self.scroll_inner)
+        self.scroll_inner = QtWidgets.QFrame(self)
+        self.boxes_layout = QtWidgets.QVBoxLayout(self.scroll_inner)
         self.scroll_area.setWidget(self.scroll_inner)
         self.scroll_area.setWidgetResizable(True)
 
-        self.Vlayout = QtGui.QVBoxLayout(self)
+        self.Vlayout = QtWidgets.QVBoxLayout(self)
         self.Vlayout.addLayout(self.Hlayout)
         self.Vlayout.addWidget(self.scroll_area)
 
@@ -203,15 +203,15 @@ class Run_experiment_tab(QtGui.QWidget):
         # Hardware test.
         if experiment['hardware_test'] != 'no hardware test':
             reply = QtGui.QMessageBox.question(self, 'Hardware test', 'Run hardware test?',
-                QtGui.QMessageBox.Yes | QtGui.QMessageBox.No)
-            if reply == QtGui.QMessageBox.Yes:
+                QtGui.QMessageBox.StandardButton.Yes | QtGui.QMessageBox.StandardButton.No)
+            if reply == QtGui.QMessageBox.StandardButton.Yes:
                 self.print_to_logs('\nStarting hardware test.')
                 self.thread_map(self.start_hardware_test)
                 if any(self.setup_failed):
                     self.abort_experiment()
                     return
                 QtGui.QMessageBox.question(self, 'Hardware test',
-                    'Press OK when finished with hardware test.', QtGui.QMessageBox.Ok)
+                    'Press OK when finished with hardware test.', QtGui.QMessageBox.StandardButton.Ok)
                 for i, board in enumerate(self.boards):
                     try:
                         board.stop_framework()
@@ -373,12 +373,12 @@ class Run_experiment_tab(QtGui.QWidget):
 
 # -----------------------------------------------------------------------------
 
-class Subjectbox(QtGui.QGroupBox):
+class Subjectbox(QtWidgets.QGroupBox):
     '''Groupbox for displaying data from a single subject.'''
 
     def __init__(self, name, setup_number, parent=None):
 
-        super(QtGui.QGroupBox, self).__init__(name, parent=parent)
+        super(QtWidgets.QGroupBox, self).__init__(name, parent=parent)
         self.board = None # Overwritten with board once instantiated.
         self.GUI_main = self.parent().GUI_main
         self.run_exp_tab = self.parent()
@@ -387,28 +387,28 @@ class Subjectbox(QtGui.QGroupBox):
         self.print_queue = []
         self.delay_printing = False
 
-        self.start_stop_button = QtGui.QPushButton('Start')
+        self.start_stop_button = QtWidgets.QPushButton('Start')
         self.start_stop_button.setIcon(QtGui.QIcon("gui/icons/play.svg"))
         self.start_stop_button.setEnabled(False)
-        self.status_label = QtGui.QLabel('Status:')
-        self.status_text = QtGui.QLineEdit()
+        self.status_label = QtWidgets.QLabel('Status:')
+        self.status_text = QtWidgets.QLineEdit()
         self.status_text.setReadOnly(True)
         self.status_text.setFixedWidth(50)
-        self.time_label = QtGui.QLabel('Time:')
-        self.time_text = QtGui.QLineEdit()
+        self.time_label = QtWidgets.QLabel('Time:')
+        self.time_text = QtWidgets.QLineEdit()
         self.time_text.setReadOnly(True)
         self.time_text.setFixedWidth(50)
         self.task_info = TaskInfo()
-        self.variables_button = QtGui.QPushButton('Variables')
+        self.variables_button = QtWidgets.QPushButton('Variables')
         self.variables_button.setIcon(QtGui.QIcon("gui/icons/filter.svg"))
         self.variables_button.setEnabled(False)
-        self.log_textbox = QtGui.QTextEdit()
+        self.log_textbox = QtWidgets.QTextEdit()
         self.log_textbox.setMinimumHeight(180)
         self.log_textbox.setFont(QtGui.QFont('Courier New',log_font_size))
         self.log_textbox.setReadOnly(True)
 
-        self.Vlayout = QtGui.QVBoxLayout(self)
-        self.Hlayout1 = QtGui.QHBoxLayout()
+        self.Vlayout = QtWidgets.QVBoxLayout(self)
+        self.Hlayout1 = QtWidgets.QHBoxLayout()
         self.Hlayout1.addWidget(self.start_stop_button)
         self.Hlayout1.addWidget(self.variables_button)
         self.Hlayout1.addWidget(self.status_label)
@@ -419,7 +419,7 @@ class Subjectbox(QtGui.QGroupBox):
         self.Hlayout1.addWidget(self.task_info.state_text)
         self.Hlayout1.addWidget(self.task_info.event_label)
         self.Hlayout1.addWidget(self.task_info.event_text)
-        self.Hlayout2 = QtGui.QHBoxLayout()
+        self.Hlayout2 = QtWidgets.QHBoxLayout()
         self.Hlayout2.addWidget(self.task_info.print_label)
         self.Hlayout2.addWidget(self.task_info.print_text)
         self.Vlayout.addLayout(self.Hlayout1)
@@ -430,9 +430,9 @@ class Subjectbox(QtGui.QGroupBox):
         if self.delay_printing:
             self.print_queue.append((print_string, end))
             return
-        self.log_textbox.moveCursor(QtGui.QTextCursor.End)
+        self.log_textbox.moveCursor(QtGui.QTextCursor.MoveOperation.End)
         self.log_textbox.insertPlainText(print_string+end)
-        self.log_textbox.moveCursor(QtGui.QTextCursor.End)
+        self.log_textbox.moveCursor(QtGui.QTextCursor.MoveOperation.End)
         self.GUI_main.app.processEvents()
 
     def start_delayed_print(self):
@@ -460,7 +460,7 @@ class Subjectbox(QtGui.QGroupBox):
                 self.variables_dialog = py_gui_file.Custom_variables_dialog(self, self.board)
 
 
-        self.variables_button.clicked.connect(self.variables_dialog.exec_)
+        self.variables_button.clicked.connect(self.variables_dialog.exec)
         self.variables_button.setEnabled(True)
         self.start_stop_button.clicked.connect(self.start_stop_task)
 

--- a/gui/run_experiment_tab.py
+++ b/gui/run_experiment_tab.py
@@ -202,16 +202,16 @@ class Run_experiment_tab(QtWidgets.QWidget):
             return
         # Hardware test.
         if experiment['hardware_test'] != 'no hardware test':
-            reply = QtGui.QMessageBox.question(self, 'Hardware test', 'Run hardware test?',
-                QtGui.QMessageBox.StandardButton.Yes | QtGui.QMessageBox.StandardButton.No)
-            if reply == QtGui.QMessageBox.StandardButton.Yes:
+            reply = QtWidgets.QMessageBox.question(self, 'Hardware test', 'Run hardware test?',
+                QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No)
+            if reply == QtWidgets.QMessageBox.StandardButton.Yes:
                 self.print_to_logs('\nStarting hardware test.')
                 self.thread_map(self.start_hardware_test)
                 if any(self.setup_failed):
                     self.abort_experiment()
                     return
-                QtGui.QMessageBox.question(self, 'Hardware test',
-                    'Press OK when finished with hardware test.', QtGui.QMessageBox.StandardButton.Ok)
+                QtWidgets.QMessageBox.question(self, 'Hardware test',
+                    'Press OK when finished with hardware test.', QtWidgets.QMessageBox.StandardButton.Ok)
                 for i, board in enumerate(self.boards):
                     try:
                         board.stop_framework()
@@ -318,10 +318,10 @@ class Run_experiment_tab(QtWidgets.QWidget):
                 time.sleep(0.05)
                 board.process_data()
                 self.subjectboxes[i].stop_task()
-        msg = QtGui.QMessageBox()
+        msg = QtWidgets.QMessageBox()
         msg.setWindowTitle('Error')
         msg.setText('An error occured while setting up experiment')
-        msg.setIcon(QtGui.QMessageBox.Warning)
+        msg.setIcon(QtWidgets.QMessageBox.Warning)
         msg.exec()
         self.startstopclose_all_button.setText('Close Exp.')
         self.startstopclose_all_button.setEnabled(True)

--- a/gui/run_task_tab.py
+++ b/gui/run_task_tab.py
@@ -2,7 +2,7 @@ import os
 import time
 import importlib
 from datetime import datetime
-from pyqtgraph.Qt import QtGui, QtCore
+from pyqtgraph.Qt import QtGui, QtCore, QtWidgets
 from serial import SerialException, SerialTimeoutException
 
 from com.pycboard import Pycboard, PyboardError, _djb2_file
@@ -22,9 +22,9 @@ from gui.utility import init_keyboard_shortcuts, TaskSelectMenu, TaskInfo
 ## Create widgets.
 
 
-class Run_task_tab(QtGui.QWidget):
+class Run_task_tab(QtWidgets.QWidget):
     def __init__(self, parent=None):
-        super(QtGui.QWidget, self).__init__(parent)
+        super(QtWidgets.QWidget, self).__init__(parent)
 
         # Variables.
         self.GUI_main = self.parent()
@@ -33,7 +33,7 @@ class Run_task_tab(QtGui.QWidget):
         self.task_hash = None  # Used to check if file has changed.
         self.data_dir = None  # Folder to save data files.
         self.custom_dir = False  # True if data_dir field has been changed from default.
-        self.connected = False  # Whether gui is conencted to pyboard.
+        self.connected = False  # Whether gui is connected to pyboard.
         self.uploaded = False  # Whether selected task file is on board.
         self.fresh_task = None  # Whether task has been run or variables edited.
         self.running = False
@@ -42,29 +42,29 @@ class Run_task_tab(QtGui.QWidget):
 
         # GUI groupbox.
 
-        self.status_groupbox = QtGui.QGroupBox("Status")
+        self.status_groupbox = QtWidgets.QGroupBox("Status")
 
-        self.status_text = QtGui.QLineEdit("Not connected")
+        self.status_text = QtWidgets.QLineEdit("Not connected")
         self.status_text.setReadOnly(True)
 
-        self.guigroup_layout = QtGui.QHBoxLayout()
+        self.guigroup_layout = QtWidgets.QHBoxLayout()
         self.guigroup_layout.addWidget(self.status_text)
         self.status_groupbox.setLayout(self.guigroup_layout)
 
         # Board groupbox
 
-        self.board_groupbox = QtGui.QGroupBox("Setup")
+        self.board_groupbox = QtWidgets.QGroupBox("Setup")
 
-        self.board_select = QtGui.QComboBox()
+        self.board_select = QtWidgets.QComboBox()
         self.board_select.addItems(["No setups found"])
-        self.board_select.setSizeAdjustPolicy(0)
-        self.connect_button = QtGui.QPushButton("Connect")
+        self.board_select.setSizeAdjustPolicy(QtWidgets.QComboBox.SizeAdjustPolicy.AdjustToContents)
+        self.connect_button = QtWidgets.QPushButton("Connect")
         self.connect_button.setIcon(QtGui.QIcon("gui/icons/connect.svg"))
         self.connect_button.setEnabled(False)
-        self.config_button = QtGui.QPushButton("Config")
+        self.config_button = QtWidgets.QPushButton("Config")
         self.config_button.setIcon(QtGui.QIcon("gui/icons/settings.svg"))
 
-        self.boardgroup_layout = QtGui.QHBoxLayout()
+        self.boardgroup_layout = QtWidgets.QHBoxLayout()
         self.boardgroup_layout.addWidget(self.board_select)
         self.boardgroup_layout.addWidget(self.connect_button)
         self.boardgroup_layout.addWidget(self.config_button)
@@ -75,18 +75,18 @@ class Run_task_tab(QtGui.QWidget):
 
         # File groupbox
 
-        self.file_groupbox = QtGui.QGroupBox("Data file")
+        self.file_groupbox = QtWidgets.QGroupBox("Data file")
 
-        self.data_dir_label = QtGui.QLabel("Data dir:")
-        self.data_dir_label.setAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
-        self.data_dir_text = QtGui.QLineEdit(dirs["data"])
-        self.data_dir_button = QtGui.QPushButton()
+        self.data_dir_label = QtWidgets.QLabel("Data dir:")
+        self.data_dir_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
+        self.data_dir_text = QtWidgets.QLineEdit(dirs["data"])
+        self.data_dir_button = QtWidgets.QPushButton()
         self.data_dir_button.setIcon(QtGui.QIcon("gui/icons/folder.svg"))
         self.data_dir_button.setFixedWidth(30)
-        self.subject_label = QtGui.QLabel("Subject ID:")
-        self.subject_text = QtGui.QLineEdit()
+        self.subject_label = QtWidgets.QLabel("Subject ID:")
+        self.subject_text = QtWidgets.QLineEdit()
 
-        self.filegroup_layout = QtGui.QGridLayout()
+        self.filegroup_layout = QtWidgets.QGridLayout()
         self.filegroup_layout.addWidget(self.data_dir_label, 0, 0)
         self.filegroup_layout.addWidget(self.data_dir_text, 0, 1)
         self.filegroup_layout.addWidget(self.data_dir_button, 0, 2)
@@ -101,16 +101,16 @@ class Run_task_tab(QtGui.QWidget):
 
         # Task groupbox
 
-        self.task_groupbox = QtGui.QGroupBox("Task")
+        self.task_groupbox = QtWidgets.QGroupBox("Task")
 
         self.task_select = TaskSelectMenu("select task")
         self.task_select.set_callback(self.task_changed)
-        self.upload_button = QtGui.QPushButton("Upload")
+        self.upload_button = QtWidgets.QPushButton("Upload")
         self.upload_button.setIcon(QtGui.QIcon("gui/icons/circle-arrow-up.svg"))
-        self.variables_button = QtGui.QPushButton("Variables")
+        self.variables_button = QtWidgets.QPushButton("Variables")
         self.variables_button.setIcon(QtGui.QIcon("gui/icons/filter.svg"))
 
-        self.taskgroup_layout = QtGui.QGridLayout()
+        self.taskgroup_layout = QtWidgets.QGridLayout()
         self.taskgroup_layout.addWidget(self.task_select, 0, 0, 1, 2)
         self.taskgroup_layout.addWidget(self.upload_button, 1, 0)
         self.taskgroup_layout.addWidget(self.variables_button, 1, 1)
@@ -120,16 +120,16 @@ class Run_task_tab(QtGui.QWidget):
 
         # Session groupbox.
 
-        self.session_groupbox = QtGui.QGroupBox("Session")
+        self.session_groupbox = QtWidgets.QGroupBox("Session")
 
-        self.start_button = QtGui.QPushButton("Start")
+        self.start_button = QtWidgets.QPushButton("Start")
         self.start_button.setIcon(QtGui.QIcon("gui/icons/play.svg"))
-        self.stop_button = QtGui.QPushButton("Stop")
+        self.stop_button = QtWidgets.QPushButton("Stop")
         self.stop_button.setIcon(QtGui.QIcon("gui/icons/stop.svg"))
 
         self.task_info = TaskInfo()
 
-        self.sessiongroup_layout = QtGui.QGridLayout()
+        self.sessiongroup_layout = QtWidgets.QGridLayout()
         self.sessiongroup_layout.addWidget(self.task_info.print_label, 0, 1)
         self.sessiongroup_layout.addWidget(self.task_info.print_text, 0, 2, 1, 3)
         self.sessiongroup_layout.addWidget(self.task_info.state_label, 1, 1)
@@ -145,7 +145,7 @@ class Run_task_tab(QtGui.QWidget):
 
         # Log text and task plots.
 
-        self.log_textbox = QtGui.QTextEdit()
+        self.log_textbox = QtWidgets.QTextEdit()
         self.log_textbox.setFont(QtGui.QFont("Courier New", log_font_size))
         self.log_textbox.setReadOnly(True)
 
@@ -154,10 +154,10 @@ class Run_task_tab(QtGui.QWidget):
 
         # Main layout
 
-        self.vertical_layout = QtGui.QVBoxLayout()
-        self.horizontal_layout_1 = QtGui.QHBoxLayout()
-        self.horizontal_layout_2 = QtGui.QHBoxLayout()
-        self.horizontal_layout_3 = QtGui.QHBoxLayout()
+        self.vertical_layout = QtWidgets.QVBoxLayout()
+        self.horizontal_layout_1 = QtWidgets.QHBoxLayout()
+        self.horizontal_layout_2 = QtWidgets.QHBoxLayout()
+        self.horizontal_layout_3 = QtWidgets.QHBoxLayout()
 
         self.horizontal_layout_1.addWidget(self.status_groupbox)
         self.horizontal_layout_1.addWidget(self.board_groupbox)
@@ -193,9 +193,9 @@ class Run_task_tab(QtGui.QWidget):
     # General methods
 
     def print_to_log(self, print_string, end="\n"):
-        self.log_textbox.moveCursor(QtGui.QTextCursor.End)
+        self.log_textbox.moveCursor(QtGui.QTextCursor.MoveOperation.End)
         self.log_textbox.insertPlainText(print_string + end)
-        self.log_textbox.moveCursor(QtGui.QTextCursor.End)
+        self.log_textbox.moveCursor(QtGui.QTextCursor.MoveOperation.End)
         self.GUI_main.app.processEvents()  # To update gui during long operations that print progress.
 
     def test_data_path(self):
@@ -236,7 +236,7 @@ class Run_task_tab(QtGui.QWidget):
 
     def open_config_dialog(self):
         """Open the config dialog and update GUI as required by chosen config."""
-        self.GUI_main.config_dialog.exec_(self.board)
+        self.GUI_main.config_dialog.exec(self.board)
         self.task_changed()
         if self.GUI_main.config_dialog.disconnect:
             time.sleep(0.5)
@@ -326,7 +326,7 @@ class Run_task_tab(QtGui.QWidget):
                     py_gui_file = importlib.import_module(f"config.user_variable_dialogs.{custom_variables_name}")
                     importlib.reload(py_gui_file)
                     self.variables_dialog = py_gui_file.Custom_variables_dialog(self, self.board)
-            self.variables_button.clicked.connect(self.variables_dialog.exec_)
+            self.variables_button.clicked.connect(self.variables_dialog.exec)
             self.variables_button.setEnabled(True)
             self.task_plot.set_state_machine(self.board.sm_info)
             self.task_info.set_state_machine(self.board.sm_info)
@@ -357,10 +357,10 @@ class Run_task_tab(QtGui.QWidget):
                     self,
                     "Reset task",
                     "Task has already been run, variables may not have default values.\n\nReset task?",
-                    QtGui.QMessageBox.Yes,
-                    QtGui.QMessageBox.No,
+                    QtGui.QMessageBox.StandardButton.Yes,
+                    QtGui.QMessageBox.StandardButton.No,
                 )
-                if reset_task == QtGui.QMessageBox.Yes:
+                if reset_task == QtGui.QMessageBox.StandardButton.Yes:
                     self.setup_task()
                     return
             subject_ID = str(self.subject_text.text())

--- a/gui/run_task_tab.py
+++ b/gui/run_task_tab.py
@@ -344,7 +344,7 @@ class Run_task_tab(QtWidgets.QWidget):
             self.status_text.setText("Error setting up state machine.")
 
     def select_data_dir(self):
-        new_path = QtGui.QFileDialog.getExistingDirectory(self, "Select data folder", dirs["data"])
+        new_path = QtWidgets.QFileDialog.getExistingDirectory(self, "Select data folder", dirs["data"])
         if new_path:
             self.data_dir_text.setText(new_path)
             self.custom_dir = True
@@ -353,14 +353,14 @@ class Run_task_tab(QtWidgets.QWidget):
         recording = self.test_data_path()
         if recording:
             if not self.fresh_task:
-                reset_task = QtGui.QMessageBox.question(
+                reset_task = QtWidgets.QMessageBox.question(
                     self,
                     "Reset task",
                     "Task has already been run, variables may not have default values.\n\nReset task?",
-                    QtGui.QMessageBox.StandardButton.Yes,
-                    QtGui.QMessageBox.StandardButton.No,
+                    QtWidgets.QMessageBox.StandardButton.Yes,
+                    QtWidgets.QMessageBox.StandardButton.No,
                 )
-                if reset_task == QtGui.QMessageBox.StandardButton.Yes:
+                if reset_task == QtWidgets.QMessageBox.StandardButton.Yes:
                     self.setup_task()
                     return
             subject_ID = str(self.subject_text.text())

--- a/gui/setups_tab.py
+++ b/gui/setups_tab.py
@@ -1,18 +1,18 @@
 import os
 import json
 
-from pyqtgraph.Qt import QtGui, QtCore
+from pyqtgraph.Qt import QtGui, QtCore, QtWidgets
 
 from config.paths import dirs
 from com.pycboard import Pycboard, PyboardError
 from gui.utility import TableCheckbox
 
-class Setups_tab(QtGui.QWidget):
+class Setups_tab(QtWidgets.QWidget):
     '''The setups tab is used to name and configure setups, where one setup is one
     pyboard and connected hardware.'''
 
     def __init__(self, parent=None):
-        super(QtGui.QWidget, self).__init__(parent)
+        super(QtWidgets.QWidget, self).__init__(parent)
 
         # Variables
 
@@ -32,47 +32,47 @@ class Setups_tab(QtGui.QWidget):
 
         # Select setups group box.
 
-        self.select_groupbox = QtGui.QGroupBox('Setups')
+        self.select_groupbox = QtWidgets.QGroupBox('Setups')
 
-        self.select_all_button = QtGui.QPushButton('Select all')
+        self.select_all_button = QtWidgets.QPushButton('Select all')
         self.select_all_button.setIcon(QtGui.QIcon("gui/icons/checkbox_checked.svg"))
-        self.deselect_all_button = QtGui.QPushButton('Deselect all')
+        self.deselect_all_button = QtWidgets.QPushButton('Deselect all')
         self.deselect_all_button.setIcon(QtGui.QIcon("gui/icons/checkbox_empty.svg"))
 
         self.select_all_button.clicked.connect(self.select_all_setups)
         self.deselect_all_button.clicked.connect(self.deselect_all_setups)
 
-        self.setups_table = QtGui.QTableWidget(0, 4, parent=self)
+        self.setups_table = QtWidgets.QTableWidget(0, 4, parent=self)
         self.setups_table.setHorizontalHeaderLabels(['Serial port', 'Name', 'Select', 'Configure'])
-        self.setups_table.horizontalHeader().setResizeMode(QtGui.QHeaderView.Stretch)
+        self.setups_table.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Stretch)
         self.setups_table.verticalHeader().setVisible(False)
         self.setups_table.itemChanged.connect(
             lambda item: item.changed() if hasattr(item, 'changed') else None)
 
-        self.select_Hlayout = QtGui.QHBoxLayout()
+        self.select_Hlayout = QtWidgets.QHBoxLayout()
         self.select_Hlayout.addWidget(self.select_all_button)
         self.select_Hlayout.addWidget(self.deselect_all_button)
-        self.select_Vlayout = QtGui.QVBoxLayout(self.select_groupbox)
+        self.select_Vlayout = QtWidgets.QVBoxLayout(self.select_groupbox)
 
         self.select_Vlayout.addLayout(self.select_Hlayout)
         self.select_Vlayout.addWidget(self.setups_table)
 
         # Configure groupbox.
 
-        self.configure_groupbox = QtGui.QGroupBox('Configure selected')
+        self.configure_groupbox = QtWidgets.QGroupBox('Configure selected')
         self.configure_groupbox.setEnabled(False)
 
-        self.load_fw_button = QtGui.QPushButton('Load framework')
-        self.load_hw_button = QtGui.QPushButton('Load hardware definition')
-        self.enable_flashdrive_button = QtGui.QPushButton('Enable flashdrive')
-        self.disable_flashdrive_button = QtGui.QPushButton('Disable flashdrive')
+        self.load_fw_button = QtWidgets.QPushButton('Load framework')
+        self.load_hw_button = QtWidgets.QPushButton('Load hardware definition')
+        self.enable_flashdrive_button = QtWidgets.QPushButton('Enable flashdrive')
+        self.disable_flashdrive_button = QtWidgets.QPushButton('Disable flashdrive')
 
         self.load_fw_button.clicked.connect(self.load_framework)
         self.load_hw_button.clicked.connect(self.load_hardware_definition)
         self.enable_flashdrive_button.clicked.connect(self.enable_flashdrive)
         self.disable_flashdrive_button.clicked.connect(self.disable_flashdrive)
 
-        self.config_layout = QtGui.QHBoxLayout(self.configure_groupbox)
+        self.config_layout = QtWidgets.QHBoxLayout(self.configure_groupbox)
         self.config_layout.addWidget(self.load_fw_button)
         self.config_layout.addWidget(self.load_hw_button)
         self.config_layout.addWidget(self.enable_flashdrive_button)
@@ -80,22 +80,22 @@ class Setups_tab(QtGui.QWidget):
 
         # Log textbox.
 
-        self.log_textbox = QtGui.QTextEdit()
+        self.log_textbox = QtWidgets.QTextEdit()
         self.log_textbox.setMinimumHeight(180)
         self.log_textbox.setFont(QtGui.QFont('Courier', 9))
         self.log_textbox.setReadOnly(True)
 
         # Main layout.
 
-        self.VLayout = QtGui.QVBoxLayout(self)
+        self.VLayout = QtWidgets.QVBoxLayout(self)
         self.VLayout.addWidget(self.select_groupbox)
         self.VLayout.addWidget(self.configure_groupbox)
         self.VLayout.addWidget(self.log_textbox)
 
     def print_to_log(self, print_string, end='\n'):
-        self.log_textbox.moveCursor(QtGui.QTextCursor.End)
+        self.log_textbox.moveCursor(QtGui.QTextCursor.MoveOperation.End)
         self.log_textbox.insertPlainText(print_string+end)
-        self.log_textbox.moveCursor(QtGui.QTextCursor.End)
+        self.log_textbox.moveCursor(QtGui.QTextCursor.MoveOperation.End)
         self.GUI_main.app.processEvents()
 
     def select_all_setups(self):
@@ -195,17 +195,17 @@ class Setup():
         self.setups_tab = setups_tab
         self.board = None
 
-        self.port_item = QtGui.QTableWidgetItem()
+        self.port_item = QtWidgets.QTableWidgetItem()
         self.port_item.setText(serial_port)
-        self.port_item.setFlags(QtCore.Qt.ItemIsEnabled)
+        self.port_item.setFlags(QtCore.Qt.ItemFlag.ItemIsEnabled)
 
-        self.name_item = QtGui.QTableWidgetItem()
+        self.name_item = QtWidgets.QTableWidgetItem()
         self.name_item.changed = self.name_edited
         if self.name != self.port: 
             self.name_item.setText(self.name)
 
         self.select_checkbox = TableCheckbox()
-        self.config_button = QtGui.QPushButton('Configure')
+        self.config_button = QtWidgets.QPushButton('Configure')
         self.config_button.setIcon(QtGui.QIcon("gui/icons/settings.svg"))
         self.config_button.clicked.connect(self.open_config_dialog)
 
@@ -234,7 +234,7 @@ class Setup():
         '''Open the config dialog and update board status as required.'''
         if not self.board: self.connect()
         if self.board:
-            self.setups_tab.GUI_main.config_dialog.exec_(self.board)
+            self.setups_tab.GUI_main.config_dialog.exec(self.board)
             if self.setups_tab.GUI_main.config_dialog.disconnect:
                 self.disconnect()
 

--- a/gui/setups_tab.py
+++ b/gui/setups_tab.py
@@ -158,7 +158,7 @@ class Setups_tab(QtWidgets.QWidget):
             setup.disable_flashdrive()
 
     def load_hardware_definition(self):
-        hwd_path = QtGui.QFileDialog.getOpenFileName(self, 'Select hardware definition:',
+        hwd_path = QtWidgets.QFileDialog.getOpenFileName(self, 'Select hardware definition:',
             os.path.join(dirs['config'], 'hardware_definition.py'), filter='*.py')[0]
         for setup in self.get_selected_setups():
             setup.load_hardware_definition(hwd_path)

--- a/gui/utility.py
+++ b/gui/utility.py
@@ -1,5 +1,5 @@
-from pyqtgraph.Qt import QtGui, QtCore, QtWidgets
 import os
+from pyqtgraph.Qt import QtGui, QtCore, QtWidgets
 
 # --------------------------------------------------------------------------------
 # GUI utility functions, classes, variables.
@@ -14,15 +14,15 @@ variable_constants = { #  Constants that can be used in setting the value of tas
 
 # --------------------------------------------------------------------------------
 
-class TableCheckbox(QtGui.QWidget):
+class TableCheckbox(QtWidgets.QWidget):
     '''Checkbox that is centered in cell when placed in table.'''
 
     def __init__(self, parent=None):
-        super(QtGui.QWidget, self).__init__(parent)
-        self.checkbox = QtGui.QCheckBox(parent=parent)
-        self.layout = QtGui.QHBoxLayout(self)
+        super(QtWidgets.QWidget, self).__init__(parent)
+        self.checkbox = QtWidgets.QCheckBox(parent=parent)
+        self.layout = QtWidgets.QHBoxLayout(self)
         self.layout.addWidget(self.checkbox)
-        self.layout.setAlignment(QtCore.Qt.AlignCenter)
+        self.layout.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         self.layout.setContentsMargins(0,0,0,0)
 
     def isChecked(self):
@@ -46,7 +46,7 @@ def cbox_set_item(cbox, item_name, insert=False):
     '''Set the selected item in a combobox to the name provided.  If name is
     not in item list returns False if insert is False or inserts item if insert 
     is True.'''
-    index = cbox.findText(item_name, QtCore.Qt.MatchFixedString)
+    index = cbox.findText(item_name, QtCore.Qt.MatchFlag.MatchFixedString)
     if index >= 0:
          cbox.setCurrentIndex(index)
          return True
@@ -107,9 +107,6 @@ class detachableTabWidget(QtWidgets.QTabWidget):
 
         self.detachedTabs = {}
 
-        # Close all detached tabs if the application is closed explicitly
-        QtWidgets.qApp.aboutToQuit.connect(self.closeDetachedTabs) 
-
     def setMovable(self, movable):
         '''Disable default movable functionality of QTabWidget.'''
         pass
@@ -131,7 +128,7 @@ class detachableTabWidget(QtWidgets.QTabWidget):
 
         # Create a new detached tab window
         detachedTab = DetachedTab(name, contentWidget)
-        detachedTab.setWindowModality(QtCore.Qt.NonModal)
+        detachedTab.setWindowModality(QtCore.Qt.WindowModality.NonModal)
         detachedTab.setGeometry(contentWidgetRect)
         detachedTab.onCloseSignal.connect(self.attachTab)
         detachedTab.move(point)
@@ -210,8 +207,8 @@ class TabBar(QtWidgets.QTabBar):
         QtWidgets.QTabBar.__init__(self, parent)
 
         self.setAcceptDrops(True)
-        self.setElideMode(QtCore.Qt.ElideRight)
-        self.setSelectionBehaviorOnRemove(QtWidgets.QTabBar.SelectLeftTab)
+        self.setElideMode(QtCore.Qt.TextElideMode.ElideRight)
+        self.setSelectionBehaviorOnRemove(QtWidgets.QTabBar.SelectionBehavior.SelectLeftTab)
 
         self.dragStartPos = QtCore.QPoint()
         self.dragDropedPos = QtCore.QPoint()
@@ -229,7 +226,7 @@ class TabBar(QtWidgets.QTabBar):
         '''Set the starting position for a drag event when the mouse button is pressed.
         - event : a mouse press event.
         '''
-        if event.button() == QtCore.Qt.LeftButton:
+        if event.button() == QtCore.Qt.MouseButton.LeftButton:
             self.dragStartPos = event.pos()
 
         self.dragDropedPos.setX(0)
@@ -249,10 +246,10 @@ class TabBar(QtWidgets.QTabBar):
             self.dragInitiated = True
 
         # If the current movement is a drag initiated by the left button
-        if (((event.buttons() & QtCore.Qt.LeftButton)) and self.dragInitiated):
+        if (((event.buttons() & QtCore.Qt.MouseButton.LeftButton)) and self.dragInitiated):
 
             # Stop the move event
-            finishMoveEvent = QtGui.QMouseEvent(QtCore.QEvent.MouseMove, event.pos(), QtCore.Qt.NoButton, QtCore.Qt.NoButton, QtCore.Qt.NoModifier)
+            finishMoveEvent = QtGui.QMouseEvent(QtCore.QEvent.Type.MouseMove, QtCore.QPointF(event.pos()), QtCore.Qt.MouseButton.NoButton, QtCore.Qt.MouseButton.NoButton, QtCore.Qt.KeyboardModifier.NoModifier)
             QtWidgets.QTabBar.mouseMoveEvent(self, finishMoveEvent)
 
             # Convert the move event into a drag
@@ -262,7 +259,7 @@ class TabBar(QtWidgets.QTabBar):
             # Create the appearance of dragging the tab content
             pixmap = self.parent().widget(self.tabAt(self.dragStartPos)).grab()
             targetPixmap = QtGui.QPixmap(pixmap.size())
-            targetPixmap.fill(QtCore.Qt.transparent)
+            targetPixmap.fill(QtCore.Qt.GlobalColor.transparent)
             painter = QtGui.QPainter(targetPixmap)
             painter.setOpacity(0.85)
             painter.drawPixmap(0, 0, pixmap)
@@ -270,16 +267,16 @@ class TabBar(QtWidgets.QTabBar):
             drag.setPixmap(targetPixmap)
 
             # Initiate the drag
-            dropAction = drag.exec_(QtCore.Qt.MoveAction | QtCore.Qt.CopyAction)
+            dropAction = drag.exec(QtCore.Qt.DropAction.MoveAction | QtCore.Qt.DropAction.CopyAction)
 
-            # For Linux:  Here, drag.exec_() will not return MoveAction on Linux.  So it
+            # For Linux:  Here, drag.exec() will not return MoveAction on Linux.  So it
             #             must be set manually
             if self.dragDropedPos.x() != 0 and self.dragDropedPos.y() != 0:
-                dropAction = QtCore.Qt.MoveAction
+                dropAction = QtCore.Qt.DropAction.MoveAction
 
             # If the drag completed outside of the tab bar, detach the tab and move
             # the content to the current cursor position
-            if dropAction == QtCore.Qt.IgnoreAction:
+            if dropAction == QtCore.Qt.DropAction.IgnoreAction:
                 event.accept()
                 self.onDetachTabSignal.emit(self.tabAt(self.dragStartPos), self.mouseCursor.pos())
                 
@@ -297,7 +294,7 @@ class TabBar(QtWidgets.QTabBar):
 # TaskSelectMenu
 # ----------------------------------------------------------------------------------
 
-class TaskSelectMenu(QtGui.QPushButton):
+class TaskSelectMenu(QtWidgets.QPushButton):
     '''Nested menu used to select tasks. The menu items are the names of
     any .py files in root_folder and it's sub-directories.  Items are 
     nested in the menu according to the sub-directory structure. 
@@ -307,7 +304,7 @@ class TaskSelectMenu(QtGui.QPushButton):
     '''
     def __init__(self, initial_text, add_default=False):
         self.callback = lambda task: None
-        self.root_menu = QtGui.QMenu()
+        self.root_menu = QtWidgets.QMenu()
         self.add_default = add_default
         self.default_text = initial_text
         super().__init__(initial_text)
@@ -365,16 +362,19 @@ class TaskInfo():
     '''
 
     def __init__(self):
-        self.state_label = QtGui.QLabel('State:')
-        self.state_text = QtGui.QLineEdit('')
+        self.state_label = QtWidgets.QLabel('State:')
+        self.state_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight|QtCore.Qt.AlignmentFlag.AlignVCenter)
+        self.state_text = QtWidgets.QLineEdit('')
         self.state_text.setReadOnly(True)
 
-        self.event_label = QtGui.QLabel('Event:')
-        self.event_text = QtGui.QLineEdit('')
+        self.event_label = QtWidgets.QLabel('Event:')
+        self.event_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight|QtCore.Qt.AlignmentFlag.AlignVCenter)
+        self.event_text = QtWidgets.QLineEdit('')
         self.event_text.setReadOnly(True)
 
-        self.print_label = QtGui.QLabel('Print:')
-        self.print_text = QtGui.QLineEdit('')
+        self.print_label = QtWidgets.QLabel('Print:')
+        self.print_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight|QtCore.Qt.AlignmentFlag.AlignVCenter)
+        self.print_text = QtWidgets.QLineEdit('')
         self.print_text.setReadOnly(True)
 
     def process_data(self, new_data):


### PR DESCRIPTION
I was unable to run pyControl on an M1 mac-mini. There was a lack of support for installing PyQt5 on Apple silicon.

There is support for PyQt6 on Apple silicon, but I needed to make these code changes for pyControl to work. 

Here is a link to some information about the differences between PyQt5 and PyQt6: https://www.pythonguis.com/faq/pyqt5-vs-pyqt6/

The changes should be backwards compatible with PyQt5. I tested on my previous computer that only has PyQt5 and everything worked as far as I could tell. All Qt classes are being imported from PyQtGraph, and PyQtGraph takes care of automatically loading PyQt5, PyQt6, PySide2 or PySide6 from your computer.
