### PR TITLE
converted experiment configuration files from .pcx to .json

### DIFF
--- a/gui/GUI_main.py
+++ b/gui/GUI_main.py
@@ -4,6 +4,7 @@ import ctypes
 import traceback
 import logging
 
+from pathlib import Path
 from serial.tools import list_ports
 from pyqtgraph.Qt import QtGui, QtCore, QtWidgets
 
@@ -116,6 +117,7 @@ class GUI_main(QtWidgets.QMainWindow):
         shortcuts_action.setIcon(QtGui.QIcon("gui/icons/keyboard.svg"))
         help_menu.addAction(shortcuts_action)
 
+        self.pcx2json()
         self.show()
 
     def go_to_data(self):
@@ -138,12 +140,18 @@ class GUI_main(QtWidgets.QMainWindow):
         subdir_1/subdir_2/task_file_name.py'''
         task_files = []
         # this function gets called every second. Normally we would use get_setting("folder","tasks")
-        # but there no need to constantly be rereading the user_settings.json file that isn't changing
+        # but there is no need to constantly be rereading the user_settings.json file that isn't changing
         # so we use this self.task_directory variable that is only updated when a new user settting is saved
         for (dirpath, dirnames, filenames) in os.walk(self.task_directory):
             task_files += [os.path.join(dirpath, file).split(self.task_directory)[1][1:-3]
                            for file in filenames if file.endswith('.py')]
         return task_files
+
+    def pcx2json(self):
+        """Converts legacy .pcx files to .json files"""
+        exp_dir = Path(dirs['experiments'])
+        for f in exp_dir.glob('*.pcx'):
+            f.rename(f.with_suffix('.json'))
 
     def refresh(self):
         '''Called regularly when framework not running.'''
@@ -153,7 +161,7 @@ class GUI_main(QtWidgets.QMainWindow):
         if self.available_tasks_changed:
             self.available_tasks = tasks
         # Scan experiments folder.
-        experiments = [t.split('.')[0] for t in os.listdir(dirs['experiments']) if t[-4:] == '.pcx']
+        experiments = [exp_file.stem for exp_file in Path(dirs['experiments']).glob('*.json')]
         self.available_experiments_changed = experiments != self.available_experiments
         if self.available_experiments_changed:
             self.available_experiments = experiments

--- a/gui/configure_experiment_tab.py
+++ b/gui/configure_experiment_tab.py
@@ -185,7 +185,7 @@ class Configure_experiment_tab(QtWidgets.QWidget):
 
     def delete_experiment(self):
         '''Delete an experiment file after dialog to confirm deletion.'''
-        exp_path = os.path.join(dirs['experiments'], self.name_text.text()+'.pcx')
+        exp_path = os.path.join(dirs['experiments'], self.name_text.text()+'.json')
         if os.path.exists(exp_path):
             reply = QtWidgets.QMessageBox.question(
                 self,
@@ -215,10 +215,10 @@ class Configure_experiment_tab(QtWidgets.QWidget):
             setup = str(self.subjects_table.cellWidget(s,1).currentText())
             run = self.subjects_table.cellWidget(s,0).isChecked()
             d[subject] =  {'setup':setup,'run':run} # add dict subject entry
-        '''Store the current state of the experiment tab as a JSON object
-        saved in the experiments folder as .pcx file.'''
+        # Store the current state of the experiment tab as a JSON object
+        # saved in the experiments folder as .json file.
         experiment = self.experiment_dict()
-        file_name = self.name_text.text()+'.pcx'
+        file_name = self.name_text.text()+'.json'
         exp_path = os.path.join(dirs['experiments'], file_name)
         if os.path.exists(exp_path) and (exp_path != self.saved_exp_path):
             reply = QtWidgets.QMessageBox.question(
@@ -229,7 +229,7 @@ class Configure_experiment_tab(QtWidgets.QWidget):
             )
             if reply == QtWidgets.QMessageBox.StandardButton.No:
                 return False
-        with open(exp_path,'w') as exp_file:
+        with open(exp_path,'w', encoding='utf-8') as exp_file:
             exp_file.write(json.dumps(experiment, sort_keys=True, indent=4))
         if not from_dialog:
             cbox_set_item(self.experiment_select, experiment['name'], insert=True)
@@ -239,9 +239,9 @@ class Configure_experiment_tab(QtWidgets.QWidget):
         return True
 
     def load_experiment(self, experiment_name):
-        '''Load experiment  .pcx file and set fields of experiment tab.'''
-        exp_path = os.path.join(dirs['experiments'], experiment_name +'.pcx')
-        with open(exp_path,'r') as exp_file:
+        '''Load experiment  .json file and set fields of experiment tab.'''
+        exp_path = os.path.join(dirs['experiments'], experiment_name +'.json')
+        with open(exp_path,'r', encoding='utf-8') as exp_file:
             experiment = json.loads(exp_file.read())
         self.name_text.setText(experiment['name'])
         if experiment['task'] in self.GUI_main.available_tasks:
@@ -335,7 +335,7 @@ class Configure_experiment_tab(QtWidgets.QWidget):
         cancel is selected, True otherwise.'''
         if self.saved_exp_dict == self.experiment_dict():
             return True # Experiment has not been edited.
-        exp_path = os.path.join(dirs['experiments'], self.name_text.text()+'.pcx')
+        exp_path = os.path.join(dirs['experiments'], self.name_text.text()+'.json')
         dialog_text = None
         if not os.path.exists(exp_path):
             dialog_text = 'Experiment not saved, save experiment?'


### PR DESCRIPTION
All reading and writing of experiment configuration files now use .json extension
For backwards compatibility, any .pcx files in the experiments folder are automatically renamed to .json files when pyControl starts up.

This addresses https://github.com/pyControl/code/issues/58


