### PR TITLE
recognize device files that have newer class syntax

### DIFF
--- a/com/pycboard.py
+++ b/com/pycboard.py
@@ -343,7 +343,7 @@ class Pycboard(Pyboard):
         for device_file in all_device_files:
             with open(os.path.join(dirs['devices'],device_file), 'r') as f:
                 file_content = f.read()
-            pattern = "[\n\r]class\s*(?P<dcname>\w+)\s*\("
+            pattern = "[\n\r]class\s*(?P<dcname>\w+)\s*"
             list(set([d_name for d_name in re.findall(pattern, file_content)]))
             device_classes = list(set([device_class for device_class in re.findall(pattern, file_content)]))
             for device_class in device_classes:


### PR DESCRIPTION
Since Python 3, [classes don't need parentheses](https://docs.python.org/3/tutorial/classes.html#class-definition-syntax) if they are not inheriting another class.

This fixes a bug where if you had a device class defined with the new syntax, it would not get recognized and uploaded to the board