### PR TITLE
fixed bug where long statements could get lost if followed closely by a variable message

### DIFF
--- a/source/communication/data_logger.py
+++ b/source/communication/data_logger.py
@@ -139,7 +139,7 @@ class Data_logger:
                         for var_name, var_value in sorted(variables_dict.items(), key=lambda x: x[0].lower()):
                             var_str += f'\t\t\t"{var_name}": {var_value}\n'
                         var_str += "\t\t\t}"
-                data_string = self.tsv_row_str("variable", time, nd.subtype, content=var_str)
+                data_string += self.tsv_row_str("variable", time, nd.subtype, content=var_str)
             elif nd.type == MsgType.WARNG:  # Warning
                 data_string += self.tsv_row_str("warning", time, content=nd.content)
             elif nd.type in (MsgType.ERROR, MsgType.STOPF):  # Error or stop framework.


### PR DESCRIPTION
significant bug where some text wouldn't get written to data log. Only noticed once I tried using on a task that had multiple statements printed immediately at startup. 

before I was getting this:
![Screenshot 2024-01-12 at 12 00 47 PM](https://github.com/pyControl/code/assets/8128628/e058d249-b0ac-4fb8-8f19-c3267404181c)

after this fix, I am now getting the full: 
![Screenshot 2024-01-12 at 12 00 06 PM](https://github.com/pyControl/code/assets/8128628/1950ebaa-f5be-4348-b922-7ba8112c02ab)

unfortunately this bug was effecting both the GUI log and the saved session.tsv

