### PR TITLE
fix disabled hardware variable save button bug

### DIFF
--- a/source/gui/hardware_variables_dialog.py
+++ b/source/gui/hardware_variables_dialog.py
@@ -106,8 +106,8 @@ class VariablesTable(QtWidgets.QTableWidget):
                     value_edit.setText(str(value))
             self.setCellWidget(row, 0, setup_name)
             self.setCellWidget(row, 1, value_edit)
+            value_edit.textChanged.connect(self.refresh_save_button)
         self.last_saved_dict = self.get_hw_var_dict()
-        value_edit.textChanged.connect(self.refresh_save_button)
 
     def refresh_save_button(self):
         if self.get_hw_var_dict() != self.last_saved_dict:


### PR DESCRIPTION
https://github.com/pyControl/code/assets/8128628/1b2c7d03-a6d4-42b8-93b0-86a59bce70f0

If the hardware variables for multiple setups are being edited, the save button will only become enabled if the last variable in the table has changed. This fixes the bug so that the save button becomes enabled if any of the variables is changed.



