### PR TITLE
mask output data checksum to 2 bytes

### DIFF
--- a/source/pyControl/framework.py
+++ b/source/pyControl/framework.py
@@ -88,7 +88,7 @@ def output_data(event):
     content_bytes = str(event.content).encode() if event.content else b""
     message = timestamp + event.type + subtype_byte + content_bytes
     message_len = len(message).to_bytes(2, "little")
-    checksum = sum(message).to_bytes(2, "little")
+    checksum = (sum(message) & 0xFFFF).to_bytes(2, "little")
     usb_serial.send(b"\x07" + checksum + message_len + message)
 
 


### PR DESCRIPTION
I ran into an error after upgrading to Micropython v1.24

One of our tasks has many variables, and as a consequence the "content" of the variable run_start message is very long:

```tsv
0.000	variable	run_start	{"in_purgatory___": false, "blocks": [[1, ["LLR", 300, 1.0, true, false], ["RRL", 300, 1.0, true, false]]], "left_dwell_range": [30, 50], "current_trial___": 1, "L_low_vol_warning_sent___": false, "trials_until_change": 0, "block_index___": -1, "match_dict___": {"prediction": "L"}, "treat_volume": 150, "reward_sequences___": [], "outcome___": "", "syringeL___": 0, "syringeR___": 0, "background_reward": [150, 0], "center_dwell_range": [30, 50], "subject___": null, "tone": "none", "right_dwell_range": [30, 50], "task_version___": 20240206, "chosen_side___": "", "outcome_delay_increase_params": [false, 50, 5000], "outcome_delay": 0, "do_increment_block_index___": true, "outcome_delay_blink_freq": 15, "R_low_vol_warning_sent___": false, "api_class": "Sequence_api", "custom_controls_dialog": "sequence_gui", "block_lengths": [300, 10]}
```
This long message has a checksum value that is greater than 2 bytes. Previously, the `to_bytes(2, "little")` would only convert the lower 2 bytes, but after the upgrade, I was getting the following error:
```python
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pyControl/framework.py", line 175, in run
  File "pyControl/framework.py", line 91, in output_data
OverflowError: buffer too small
```

In [version 1.24 release notes](https://github.com/micropython/micropython/releases/tag/v1.24.0) it's noted that there are now buffer size checks
> bare-arm, minimal: fix int.to_bytes() buffer size checks

The small change in this commit prevents the error by masking everything off but the last 2 bytes for the checksum. The computer side code that is receiving the serial message is already using a similar mask when checking the checksum: 
https://github.com/pyControl/code/blob/c5b6999194d33a97c549e7789e55804f600bd702/source/communication/pycboard.py#L488

