### PR TITLE
fix bad timestamp for API print event

### DIFF
--- a/source/communication/pycboard.py
+++ b/source/communication/pycboard.py
@@ -486,10 +486,9 @@ class Pycboard(Pyboard):
                     msg_sum = sum(message)
                 # Process message.
                 if checksum == (msg_sum & 0xFFFF):  # Checksum OK.
-                    time_of_processing = time.time()
                     msg_timestamp = int.from_bytes(message[:4], "little")
                     if msg_timestamp > self.timestamp:
-                        self.last_message_time = time_of_processing
+                        self.last_message_time = time.time()
                         self.timestamp = msg_timestamp
                     if msg_type in (MsgType.EVENT, MsgType.STATE):
                         content = int(content_bytes.decode())  # Event/state ID.

--- a/source/communication/pycboard.py
+++ b/source/communication/pycboard.py
@@ -485,7 +485,7 @@ class Pycboard(Pyboard):
                 else:
                     message_sum = sum(message)
                 # Process message.
-                if checksum == message_sum & 0xFFFF:  # Checksum OK.
+                if checksum == (message_sum & 0xFFFF):  # Checksum OK.
                     self.last_message_time = time.time()
                     self.timestamp = int.from_bytes(message[:4], "little")
                     if msg_type in (MsgType.EVENT, MsgType.STATE):


### PR DESCRIPTION
It was possible for an analog message to enter the message processing queue and have its older timestamp assigned as the latest timestamp. If the timing was just right, this could occasionally cause the get_timestamp() function to produce an out of sequence/incorrect timestamp.

This commit fixes the problem by only updating the latest timestamp with the message's timestamp, if the message's timestamp is newer.

The error can be reproduced with the files below:
### task.py
```python
from pyControl.utility import *
from devices import Breakout_1_2, Poke, Rotary_encoder

bb = Breakout_1_2()  # breakout board
center_poke = Poke(bb.port_2, rising_event="center_in")
running_wheel = Rotary_encoder(
    name="running_wheel",
    sampling_rate=40,
)

states = ["stateA"]
events = ["center_in"]

initial_state = "stateA"

v.api_class = "my_api"


def stateA(event):
    pass

```

### my_api.py
```python
from source.gui.api import Api


class my_api(Api):
    def __init__(self):
        pass

    def process_data_user(self, data):
        new_events = [new_event.name for new_event in data["events"]]
        for event in new_events:
            if event == "center_in":
                self.print_message("hi")

```

The log should show that the api print event occurs about 1ms after the poke event. As seen below, sometimes the timestamp for the api print is wrong.
![CleanShot 2025-03-20 at 17 56 07](https://github.com/user-attachments/assets/a9201642-4e2f-4dd5-ae95-a13d822244de)

