### PR TITLE
fix timer conflict between rotary encoder and audio output (again)

### DIFF
--- a/source/pyControl/audio.py
+++ b/source/pyControl/audio.py
@@ -36,21 +36,21 @@ class Audio_output(hw.IO_object):
     # User functions
 
     def off(self):
-        self._DAC.write_timed(_off_buf, pyb.Timer(2, freq=10000), mode=pyb.DAC.NORMAL)
+        self._DAC.write_timed(_off_buf, pyb.Timer(4, freq=10000), mode=pyb.DAC.NORMAL)
         self._timer.deinit()
         self._playing = False
 
     def sine(self, freq):  # Play a sine wave tone at the specified frequency.
-        self._DAC.write_timed(_sine_buf, pyb.Timer(2, freq=freq * _sine_len), mode=pyb.DAC.CIRCULAR)
+        self._DAC.write_timed(_sine_buf, pyb.Timer(4, freq=freq * _sine_len), mode=pyb.DAC.CIRCULAR)
 
     def square(self, freq):  # Play a square wave tone at the specified frequency.
-        self._DAC.write_timed(_sqr_buf, pyb.Timer(2, freq=freq * 2), mode=pyb.DAC.CIRCULAR)
+        self._DAC.write_timed(_sqr_buf, pyb.Timer(4, freq=freq * 2), mode=pyb.DAC.CIRCULAR)
 
     def noise(self, freq=10000):  # Play white noise with specified maximum frequency.
         self._DAC.noise(freq * 2)
 
     def click(self, timer=None):  # Play a single click.
-        self._DAC.write_timed(_click_buf, pyb.Timer(2, freq=40000), mode=pyb.DAC.NORMAL)
+        self._DAC.write_timed(_click_buf, pyb.Timer(4, freq=40000), mode=pyb.DAC.NORMAL)
 
     def clicks(self, rate):  # Play clicks at specified rate.
         self._timer.init(freq=rate)

--- a/source/pyControl/hardware.py
+++ b/source/pyControl/hardware.py
@@ -43,8 +43,8 @@ next_ID = 0  # Next hardware object ID.
 
 IO_dict = {}  # Dictionary {ID: IO_object} containing all hardware inputs and outputs.
 
-available_timers = [3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14]  # Hardware timers not in use
-# Used timers; 1: Framework clock tick, 2: Audio write_timed, 6: DAC write_timed.
+available_timers = [3, 5, 7, 8, 9, 10, 11, 12, 13, 14]  # Hardware timers not in use.
+# Used timers; 1: Framework clock tick, 2: Rotary encoder, 4: Audio write_timed, 6: DAC write_timed.
 
 initialised = False  # Set to True once hardware has been intiialised.
 


### PR DESCRIPTION
A conflict between timers used by the rotary encoder and audio output prevents being used at the same time

This problem was originally found and discussed [here](https://github.com/orgs/pyControl/discussions/70#discussioncomment-5017827)

It was fixed with commit 93a6611206d01b78aad2f7e45c86b3e5b1498f78 in the [v1.8.1 release](https://github.com/pyControl/code/releases/tag/v1.8.1)

Looking through the git history, I am confused/stumped as to where the code regressed. 

From what I can tell the next time `hardware.py` was changed was in ce964c3a9769915b775cfda3b4eb6ce9142051e1, but the regression back to the older list of timers isn't marked as a change...

Likewise, from what I can tell, the next time `audio.py` was changed was in 457c28e83c3bc2ffd0e777ea8561745aba2d9a29, but that commit shows that audio is back to using timer 2, and it is not marked as a change...

Anyway, I reimplemented the same changes as from 93a6611206d01b78aad2f7e45c86b3e5b1498f78

