### PR TITLE
Add UART receive interrupt handler

### DIFF
--- a/devices/uart_handler.py
+++ b/devices/uart_handler.py
@@ -1,0 +1,35 @@
+from pyControl.hardware import IO_object, assign_ID, interrupt_queue, fw, sm
+
+
+class UART_handler(IO_object):
+    """
+    This class is used to generate a framework event when a UART message is received.
+    """
+
+    def __init__(self, event_name, first_char_interrupt=True):
+        self.event_name = event_name
+        self.last_interrupt_time = 0
+        self.first_char_interrupt = first_char_interrupt
+        if self.first_char_interrupt:
+            self.msg_starting = False
+        assign_ID(self)
+
+    def _initialise(self):
+        self.event_ID = sm.events[self.event_name] if self.event_name in sm.events else False
+
+    def ISR(self, _):
+        if self.event_ID:
+            # - pyboard v1.1 (and other STM32F4 boards): IRQ_RXIDLE interrupt is triggered after the first character
+            #   AND at the end when the RX is idle.
+            # - pyboard D-series board (STM32F7): IRQ_RXIDLE interrupt is triggered ONLY at the end when the RX is idle
+            # - see Micropytyhon UART docs for more info: https://docs.micropython.org/en/latest/library/machine.UART.html
+            if self.first_char_interrupt:
+                self.msg_starting = not self.msg_starting
+                if self.msg_starting:
+                    # ignore the first interrupt after the message starts (when using pyboard v1.1)
+                    return
+            self.timestamp = fw.current_time
+            interrupt_queue.put(self.ID)
+
+    def _process_interrupt(self):
+        fw.event_queue.put(fw.Datatuple(self.timestamp, fw.EVENT_TYP, "i", self.event_ID))

--- a/source/pyControl/hardware.py
+++ b/source/pyControl/hardware.py
@@ -527,7 +527,7 @@ class UART_handler(IO_object):
     def _initialise(self):
         self.event_ID = sm.events[self.event_name] if self.event_name in sm.events else False
 
-    def _ISR(self, _):
+    def ISR(self, _):
         if self.event_ID:
             # - pyboard v1.1 (and other STM32F4 boards): IRQ_RXIDLE interrupt is triggered after the first character
             #   AND at the end when the RX is idle.

--- a/source/pyControl/hardware.py
+++ b/source/pyControl/hardware.py
@@ -510,36 +510,3 @@ class Rsync(IO_object):
         self.state = not self.state
         self.sync_pin.value(self.state)
 
-
-class UART_handler(IO_object):
-    """
-    This class is used to generate a framework event when a UART message is received.
-    """
-
-    def __init__(self, event_name, first_char_interrupt=True):
-        self.event_name = event_name
-        self.last_interrupt_time = 0
-        self.first_char_interrupt = first_char_interrupt
-        if self.first_char_interrupt:
-            self.msg_starting = False
-        assign_ID(self)
-
-    def _initialise(self):
-        self.event_ID = sm.events[self.event_name] if self.event_name in sm.events else False
-
-    def ISR(self, _):
-        if self.event_ID:
-            # - pyboard v1.1 (and other STM32F4 boards): IRQ_RXIDLE interrupt is triggered after the first character
-            #   AND at the end when the RX is idle.
-            # - pyboard D-series board (STM32F7): IRQ_RXIDLE interrupt is triggered ONLY at the end when the RX is idle
-            # - see Micropytyhon UART docs for more info: https://docs.micropython.org/en/latest/library/machine.UART.html
-            if self.first_char_interrupt:
-                self.msg_starting = not self.msg_starting
-                if self.msg_starting:
-                    # ignore the first interrupt after the message starts (when using pyboard v1.1)
-                    return
-            self.timestamp = fw.current_time
-            interrupt_queue.put(self.ID)
-
-    def _process_interrupt(self):
-        fw.event_queue.put(fw.Datatuple(self.timestamp, fw.EVENT_TYP, "i", self.event_ID))


### PR DESCRIPTION
I have a custom syringe pump that uses UART serial messages to communicate with pyControl. It is sometimes useful to receive messages from the pump, for instance to tell the task that a syringe is empty, so the task will automatically stop. 

Previously, to get this working would require constant polling the syringe pump UART to see if there were any messages available. Something like:
```python
from pyControl.utility import *
from devices import PumpController, Breakout_dseries_1_6

bb = Breakout_dseries_1_6()  # breakout board
syringes = PumpController(port=bb.port_11)

states = ["state_A"]
events = ["check_for_message"]

initial_state = "state_A"


def run_start():
    set_timer("check_for_message", 200, output_event=False)


def all_states(event):
    if event == "check_for_message":
        set_timer("check_for_message", 200, output_event=False)
        msg = syringes.read_serial()
        if msg == "syringe_empty":
            stop_framework()
        else:
            print(msg)


def state_A(event):
    pass
```
This pull request adds a `UART_handler` class that can be attached to a UART's RX interrupt. Now a pyControl framework event will be output whenever a UART message is received. So the task code now looks something like this:
```python
from pyControl.utility import *
from devices import PumpController, Breakout_dseries_1_6

bb = Breakout_dseries_1_6()  # breakout board
syringes = PumpController(port=bb.port_11, event_name="msg_received")

states = ["state_A"]
events = ["msg_received"]

initial_state = "mystate"


def all_states(event):
    if event == "msg_received":
        msg = syringes.read_serial()
        if msg == "syringe_empty":
            stop_framework()
        else:
            print(msg)


def state_A(event):
    pass
```

This gets rid of the constantly polling timer and greatly reduces response time. 

Here is a look at my PumpController device class to see how it is implemented:
```python
from machine import UART
from pyControl.hardware import UART_handler


class PumpController:
    def __init__(self, port, event_name, pybv1=False):
        assert port.UART is not None, "! Pump needs port with UART."

        self.uart = UART(port.UART)
        self.uart.init(115200, bits=8, parity=None, stop=1, timeout=100, rxbuf=130)

        handler = UART_handler(event_name, first_char_interrupt=pybv1)
        self.uart.irq(trigger=UART.IRQ_RXIDLE, handler=handler.ISR)

        # default pump settings
        self.configure_pump(
            steps_per_rev=200,
            syringe_id_mm=26.7,
            lead_mm=2,
            acceleration=5000,
            max_velocity=180_000,
        )
        self.uart.read()  # clear buffer
        self._send("reset")

        self._left = "l1"
        self._right = "r1"

    def _send(self, command, payload=""):
        self.uart.write(f"{command};{payload}\n")

    def configure_pump(
        self,
        steps_per_rev,
        syringe_id_mm,
        lead_mm,
        acceleration,
        max_velocity,
        pump="all",
    ):
        if pump == "all":
            for pump in ["l1", "l2", "r1", "r2"]:
                self._send(
                    "eval",
                    f"{pump}.configure({steps_per_rev}, {syringe_id_mm}, {lead_mm}, {acceleration}, {max_velocity})",
                )
        else:
            self._send(
                "eval", f"{pump}.configure({steps_per_rev}, {syringe_id_mm}, {lead_mm}, {acceleration}, {max_velocity})"
            )

    def display_animal_number(self, number):
        self._send("animal", number)

    def stop(self):
        self._send("stop")

    def infuse(self, pump, volume):
        self._send("eval", f"{pump}.dispense({volume})")

    def left_infuse(self, volume):
        self.infuse(self._left, volume)

    def right_infuse(self, volume):
        self.infuse(self._right, volume)

    def get_version(self):
        self._send("version")

    def read_serial(self):
        if self.uart.any():
            return self.uart.readline().decode("utf-8").strip("\n")
        return None

```

This improves the [situation described in the docs](https://pycontrol.readthedocs.io/en/latest/user-guide/programming-tasks/#writing-performant-task-code)

> Polling may be necessary if you need to respond to events send over a serial connection (e.g. from an external device that communicates via UART). In this case either poll at the lowest frequency necessary to ensure an acceptable response latency to the serial input, or if possible trigger the serial read using a separate digital input from the external device