### PR TITLE
Plot height and axis width improvements

### DIFF
--- a/source/gui/plotting.py
+++ b/source/gui/plotting.py
@@ -57,18 +57,29 @@ class Task_plot(QtWidgets.QWidget):
         self.states_plot.set_state_machine(sm_info)
         self.events_plot.set_state_machine(sm_info)
         self.analog_plot.set_state_machine(sm_info)
+
+        # size the states and events plots relative to the number of states and events
+        num_states = max(1, len(sm_info.states))
+        num_events = max(1, len(sm_info.events))
+        total = num_states + num_events
+        states_fraction = num_states / total
+        events_fraction = num_events / total
+
         if self.analog_plot.inputs:
+            # state and event plots are 2/3 of the total height
+            # analog plot is 1/3 of the total height
             self.analog_plot.axis.setVisible(True)
             self.events_plot.axis.getAxis("bottom").setLabel("")
-            self.layout.setRowStretch(0, 1)
-            self.layout.setRowStretch(1, 1)
-            self.layout.setRowStretch(2, 1)
+            self.layout.setRowStretch(0, int(states_fraction * 66))  # States plot
+            self.layout.setRowStretch(1, int(events_fraction * 66))  # Events plot
+            self.layout.setRowStretch(2, 33)  # Analog plot
         else:
+            # state and event plots
             self.analog_plot.axis.setVisible(False)
             self.events_plot.axis.getAxis("bottom").setLabel("Time (seconds)")
-            self.layout.setRowStretch(0, 1)
-            self.layout.setRowStretch(1, 1)
-            self.layout.setRowStretch(2, 0)
+            self.layout.setRowStretch(0, int(states_fraction * 100))  # States plot
+            self.layout.setRowStretch(1, int(events_fraction * 100))  # Events plot
+            self.layout.setRowStretch(2, 0)  # No analog plot
 
     def run_start(self, recording):
         self.pause_button.setChecked(False)

--- a/source/gui/plotting.py
+++ b/source/gui/plotting.py
@@ -47,7 +47,13 @@ class Task_plot(QtWidgets.QWidget):
 
     def set_state_machine(self, sm_info):
         # Initialise plots with state machine information.
-        self.axiswidth = 6 + 6 * max([len(n) for n in list(sm_info.states) + list(sm_info.events)])
+
+        font = QtGui.QFont()  # inherits application font size
+        metrics = QtGui.QFontMetrics(font)
+        max_tick_label_width = max([metrics.horizontalAdvance(n) for n in list(sm_info.states) + list(sm_info.events)])
+        padding = 10
+        self.axiswidth = max_tick_label_width + padding
+
         self.states_plot.set_state_machine(sm_info)
         self.events_plot.set_state_machine(sm_info)
         self.analog_plot.set_state_machine(sm_info)


### PR DESCRIPTION
## Axis width
Fixed a bug where the tick labels for the plots could potentially not be visible because the axis width wasn't taking into account the GUI font-size

### larger font + long label before:
![CleanShot 2025-04-09 at 14 14 03](https://github.com/user-attachments/assets/da75ff87-10d9-4437-9b88-019492e91e9f)

### after:
![CleanShot 2025-04-09 at 14 13 25](https://github.com/user-attachments/assets/1fd6b717-5053-4065-9dd0-56c62c3d8834)

## Proportional plot heights
Made the heights of the states and events plots proportional to the number of states and events.

### before:   
![CleanShot 2025-04-09 at 14 18 48](https://github.com/user-attachments/assets/fc203039-b642-4362-b872-ae595acdd825)
### after:
![CleanShot 2025-04-09 at 14 19 46](https://github.com/user-attachments/assets/0f6e2d65-d5de-42e6-ba94-cc2a37058e09)
