### PR TITLE
bugfix note timestamp

### DIFF
--- a/source/communication/pycboard.py
+++ b/source/communication/pycboard.py
@@ -421,7 +421,6 @@ class Pycboard(Pyboard):
             micropython_version=self.micropython_version,
         )
         self.data_logger.reset()
-        self.timestamp = 0
 
     def get_states(self):
         """Return states as a dictionary {state_name: state_ID}"""
@@ -440,7 +439,8 @@ class Pycboard(Pyboard):
         self.gc_collect()
         self.exec("fw.data_output = " + repr(data_output))
         self.serial.reset_input_buffer()
-        self.last_message_time = 0
+        self.last_message_time = time.time()
+        self.timestamp = 0
         self.exec_raw_no_follow("fw.run()")
         self.framework_running = True
 


### PR DESCRIPTION
If you add a note after a session has started, but before any other events happen, then the note's timestamp will be way off.

below I show what happens if you run `example/button.py` and add a note first thing:
![CleanShot 2025-05-28 at 15 10 30](https://github.com/user-attachments/assets/2e11ffac-8c14-4071-b1ee-245d8b1c5ef9)

after the fix:
![CleanShot 2025-05-28 at 15 18 53](https://github.com/user-attachments/assets/0a1dfecb-c502-456e-9a6a-514c81aee182)
