### PR TITLE
fix missing menu icons on mac

### DIFF
--- a/source/gui/GUI_main.py
+++ b/source/gui/GUI_main.py
@@ -230,6 +230,7 @@ def launch_GUI():
     app = QtWidgets.QApplication(sys.argv)
     app.setStyle("Fusion")
     app.setWindowIcon(QtGui.QIcon("source/gui/icons/logo.svg"))
+    app.setAttribute(QtCore.Qt.ApplicationAttribute.AA_DontShowIconsInMenus, False)  # enable icons in mac menus
     font = QtGui.QFont()
     font.setPixelSize(get_setting("GUI", "ui_font_size"))
     app.setFont(font)


### PR DESCRIPTION
I'm not sure if this bug appeared after a Mac update, or a PyQt update, but I noticed that the menu icons were recently missing on my Mac. I made a small change to fix the problem.

before:
![CleanShot 2025-05-28 at 16 34 01](https://github.com/user-attachments/assets/d523c382-aaac-4a82-bc1c-897239763e0e)
after:
![CleanShot 2025-05-28 at 16 34 48](https://github.com/user-attachments/assets/338c600f-24b8-494d-b91d-e19d91b0eb35)
