### PR TITLE
simplify UART handler, require Micropython version >=1.26

### DIFF
--- a/devices/uart_handler.py
+++ b/devices/uart_handler.py
@@ -1,3 +1,4 @@
+import sys
 from pyControl.hardware import IO_object, assign_ID, interrupt_queue, fw, sm
 
 
@@ -6,12 +7,11 @@ class UART_handler(IO_object):
     This class is used to generate a framework event when a UART message is received.
     """
 
-    def __init__(self, event_name, mcu="STM32_F4"):
+    def __init__(self, event_name):
+        major, minor, *_ = sys.implementation.version
+        assert (major > 1) or (major == 1 and minor >= 26), "UART_handler requires MicroPython version >= 1.26"
+
         self.event_name = event_name
-        self.last_interrupt_time = 0
-        self.mcu = mcu
-        if self.mcu == "STM32_F4":
-            self.accept_interrupt = True
         assign_ID(self)
 
     def _initialise(self):
@@ -19,18 +19,8 @@ class UART_handler(IO_object):
 
     def ISR(self, _):
         if self.event_ID:
-            # - pyboard v1.1 (and other STM32F4 boards): IRQ_RXIDLE interrupt is triggered after the first character
-            #   AND at the end when the RX is idle.
-            # - pyboard D-series board (STM32F7): IRQ_RXIDLE interrupt is triggered ONLY at the end when the RX is idle
-            # - see Micropytyhon UART docs for more info: https://docs.micropython.org/en/latest/library/machine.UART.html
-            if self.mcu == "STM32_F4":  # respond to every other interrupt when using pyboard v1.1
-                if self.accept_interrupt:
-                    self.timestamp = fw.current_time
-                    interrupt_queue.put(self.ID)
-                self.accept_interrupt = not self.accept_interrupt
-            elif self.mcu == "STM32_F7":  # respond to every interrupt when using pyboard D-series
-                self.timestamp = fw.current_time
-                interrupt_queue.put(self.ID)
+            self.timestamp = fw.current_time
+            interrupt_queue.put(self.ID)
 
     def _process_interrupt(self):
         fw.event_queue.put(fw.Datatuple(self.timestamp, fw.EVENT_TYP, "i", self.event_ID))


### PR DESCRIPTION
previously, there was oddness with the pyboard v1.1 (STM32F4) IRQ_RXIDLE
from the [UART docs](https://docs.micropython.org/en/v1.25.0/library/machine.UART.html#machine.UART):

> On STM32F4xx MCU’s, using the trigger UART.IRQ_RXIDLE the handler will be called once after the first character and then after the end of the message, when the line is idle

This difference in how IRQ_RXIDLE worked on pyboard v1.1 and pyboard d-series led to added complexity in UART_handler class where you had to specify `mcu=STM32_F4` or `mcu=STM32_F7`

The extra trigger after the first character has now been fixed in Micropython v1.26
from [release notes](https://github.com/micropython/micropython/releases/tag/v1.26.0):
> extmod_hardware/machine_uart_irq_rxidle.py: ignore inital IRQ

This commit has changes that simplify the UART_handler class, with the caveat that it now requires Micropython >= 1.26

